### PR TITLE
v1.7.0 — Threading, thread view, chat merge, hide accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-02-21
+
+### Added
+- **Email threading (Gmail-style)** — emails are now grouped into threads using RFC 2822 `In-Reply-To` and `References` headers, with normalized subject as fallback; the regular email list shows collapsed thread rows with participant names, message count badges, and latest date; the chat view uses the same threading algorithm for its topic grouping; Rust IMAP layer now fetches `In-Reply-To` from ENVELOPE and `References` via `BODY.PEEK[HEADER.FIELDS (References)]`
+- **Thread conversation view** — clicking a thread in the email list now shows all emails in the thread as a stacked conversation in the viewer; emails are sorted chronologically with the latest expanded by default; each email has its own reply/reply-all/forward buttons and attachment section; email bodies load progressively using the same concurrent loader as the chat view
+- **Chat view: sent message merge** — chat conversations now display both received (INBOX) and sent messages together; Sent folder headers are synced via the background pipeline and merged with INBOX emails, with deduplication by Message-ID to avoid duplicates; body loading handles per-mailbox IMAP fetches transparently
+- **Clear cache button** — Settings > General > Local Email Caching now has a "Clear Cache" button that removes all cached .eml files and headers, preserves archived emails, and restarts the sync pipeline
+- **Hide/unhide accounts** — accounts can be hidden from Settings > Accounts; hidden accounts disappear from the sidebar and stop all syncing (background pipelines, scheduled refresh); unhiding immediately resumes sync; if the active account is hidden, the app switches to the next visible account
+
+### Removed
+- **App Password fallback for OAuth2 providers** — Gmail and Microsoft accounts no longer show the "Use App Password instead" toggle; OAuth2 is the only authentication method for these providers as app passwords are less secure
+
+### Fixed
+- **Thread row actions** — threaded email rows in the list view now show archive and more-menu buttons on hover (matching single-email rows); archive button archives all emails in the thread; more menu offers "Delete thread from server" with confirmation
+- **Chat view "Content cannot be displayed"** — chat bubbles showed "Content cannot be displayed" for all messages because the chat view only received header-only emails (no body content); added progressive body loading via `useChatBodyLoader` hook that fetches email bodies concurrently (3 at a time) from cache → Maildir → IMAP, with per-bubble loading spinners and targeted re-renders
+
 ## [1.6.0] - 2026-02-20
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <meta name="twitter:title" content="MailVault — Free Local Email Backup for Mac | Store Emails Offline">
   <meta name="twitter:description" content="Back up your IMAP emails locally on macOS. MailVault stores emails offline in a local archive — keep them forever, even after server deletion. Free and open source.">
   <meta name="twitter:image" content="https://mailvaultapp.com/og-image.png">
+  <meta name="twitter:site" content="@GraphicMeat">
 
   <!-- Favicon -->
   <link rel="icon" type="image/x-icon" href="favicon.ico">
@@ -105,6 +106,9 @@
     "description": "Back up your IMAP emails locally on macOS. MailVault stores emails offline in a local archive — keep them forever, even after server deletion. Free and open source.",
     "operatingSystem": "macOS",
     "applicationCategory": "BusinessApplication",
+    "applicationSubCategory": "EmailApplication",
+    "softwareVersion": "1.6.0",
+    "datePublished": "2026-02-20",
     "offers": {
       "@type": "Offer",
       "price": "0",
@@ -112,14 +116,21 @@
     },
     "downloadUrl": "https://github.com/GraphicMeat/mail-vault-app/releases/latest",
     "featureList": [
-      "Local email storage",
-      "Privacy-first design",
-      "IMAP support",
-      "Gmail OAuth2",
-      "Microsoft 365 OAuth2",
-      "Offline access",
-      "Full-text search",
-      "Email backup"
+      "Local email storage in Maildir format",
+      "Privacy-first design — no cloud, no tracking",
+      "IMAP support for any email provider",
+      "Gmail OAuth2 sign-in",
+      "Microsoft 365 OAuth2 sign-in",
+      "Offline email access",
+      "Full-text search with filters",
+      "ZIP backup export and import",
+      "Email threading (Gmail-style conversations)",
+      "Chat conversation view",
+      "Bulk email archiving",
+      "Multi-account support",
+      "Dark and light themes",
+      "Native macOS app (Tauri, not Electron)",
+      "Auto-updater"
     ],
     "screenshot": "https://mailvaultapp.com/og-image.png",
     "author": {
@@ -584,7 +595,7 @@
           <h3 class="text-xl font-semibold mb-3">Email Management</h3>
           <ul class="space-y-2 text-slate-600 dark:text-slate-400">
             <li class="flex items-start gap-2"><svg class="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>Compose, reply, reply all, and forward</li>
-            <li class="flex items-start gap-2"><svg class="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>Gmail &amp; Microsoft 365 OAuth2 sign-in (no app password needed)</li>
+            <li class="flex items-start gap-2"><svg class="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>Gmail &amp; Microsoft 365 OAuth2 sign-in</li>
             <li class="flex items-start gap-2"><svg class="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>Advanced search (sender, date, attachments, folder)</li>
             <li class="flex items-start gap-2"><svg class="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>Bulk operations (select all, batch archive/delete)</li>
           </ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailvault",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A reactive email client with local storage capabilities",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mailvault"
-version = "1.6.0"
+version = "1.7.0"
 description = "A reactive email client with local storage"
 authors = ["MailVault"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/schema.json",
   "productName": "MailVault",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "identifier": "com.mailvault.app",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/src/components/AccountModal.jsx
+++ b/src/components/AccountModal.jsx
@@ -13,7 +13,7 @@ const PROVIDER_CONFIGS = {
     imapPort: 993,
     smtpHost: 'smtp.gmail.com',
     smtpPort: 587,
-    note: 'Sign in with Google (recommended) or use an App Password',
+    note: 'Sign in with your Google account',
     supportsOAuth2: true,
     oauth2Provider: 'google'
   },
@@ -24,7 +24,7 @@ const PROVIDER_CONFIGS = {
     imapPort: 993,
     smtpHost: 'smtp.office365.com',
     smtpPort: 587,
-    note: 'Sign in with Microsoft (recommended) or use an App Password',
+    note: 'Sign in with your Microsoft account',
     supportsOAuth2: true,
     oauth2Provider: 'microsoft'
   },
@@ -555,29 +555,6 @@ export function AccountModal({ onClose }) {
                     </div>
                   )}
 
-                  {/* Toggle to password auth */}
-                  {authType === 'oauth2' && !oauthLoading && !oauthConnected && (
-                    <button
-                      type="button"
-                      onClick={() => setAuthType('password')}
-                      className="w-full text-sm text-mail-text-muted hover:text-mail-text
-                                transition-colors py-1"
-                    >
-                      Use App Password instead
-                    </button>
-                  )}
-
-                  {/* Toggle back to OAuth2 */}
-                  {authType === 'password' && showOAuth2Option && (
-                    <button
-                      type="button"
-                      onClick={() => setAuthType('oauth2')}
-                      className="w-full text-sm text-mail-accent hover:text-mail-accent-hover
-                                transition-colors py-1"
-                    >
-                      Sign in with {providerConfig?.oauth2Provider === 'google' ? 'Google' : 'Microsoft'} instead (recommended)
-                    </button>
-                  )}
                 </div>
               )}
 
@@ -627,7 +604,7 @@ export function AccountModal({ onClose }) {
               {authType === 'password' && (
                 <div>
                   <label className="block text-sm text-mail-text-muted mb-1.5">
-                    Password / App Password *
+                    Password *
                   </label>
                   <div className="relative">
                     <Lock size={18} className="absolute left-3 top-1/2 -translate-y-1/2 text-mail-text-muted" />

--- a/src/components/ChatSenderList.jsx
+++ b/src/components/ChatSenderList.jsx
@@ -12,11 +12,12 @@ import { MessageSquare, Search } from 'lucide-react';
 export function ChatSenderList({ onSelectSender }) {
   // Subscribe to all state values that affect email display to ensure re-renders
   const {
-    getCombinedEmails,
+    getChatEmails,
     accounts,
     activeAccountId,
     emails,        // Subscribe to trigger re-render when server emails change
     localEmails,   // Subscribe to trigger re-render when local emails change
+    sentEmails,    // Subscribe to trigger re-render when sent emails load
     viewMode       // Subscribe to trigger re-render when view mode changes
   } = useMailStore();
   const [searchQuery, setSearchQuery] = React.useState('');
@@ -27,8 +28,8 @@ export function ChatSenderList({ onSelectSender }) {
     return activeAccount?.email || '';
   }, [accounts, activeAccountId]);
 
-  // Get emails directly - subscribing to emails/localEmails/viewMode above ensures this updates
-  const combinedEmails = getCombinedEmails();
+  // Get emails directly - subscribing to emails/localEmails/sentEmails/viewMode above ensures this updates
+  const combinedEmails = getChatEmails();
 
   // Group emails by correspondent
   const correspondents = useMemo(() => {
@@ -69,16 +70,16 @@ export function ChatSenderList({ onSelectSender }) {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Search Bar */}
-      <div className="p-3 border-b border-mail-border">
-        <div className="relative">
+      {/* Search Bar — matches sidebar header height (px-4 py-3) */}
+      <div data-tauri-drag-region className="px-4 py-3 border-b border-mail-border flex items-center">
+        <div className="relative w-full">
           <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-mail-text-muted" />
           <input
             type="text"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search conversations..."
-            className="w-full pl-9 pr-4 py-2 bg-mail-bg border border-mail-border rounded-lg
+            className="w-full pl-9 pr-4 py-1.5 bg-mail-bg border border-mail-border rounded-lg
                       text-mail-text placeholder-mail-text-muted text-sm
                       focus:border-mail-accent focus:outline-none"
           />

--- a/src/components/ChatTopicsList.jsx
+++ b/src/components/ChatTopicsList.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { motion } from 'framer-motion';
 import {
-  groupByTopic,
+  buildThreads,
   getAvatarColor,
   getInitials,
   formatRelativeTime
@@ -13,12 +13,12 @@ export function ChatTopicsList({ correspondent, onBack, onSelectTopic }) {
   const avatarColor = getAvatarColor(correspondent.email);
   const initials = getInitials(correspondent.name, correspondent.email);
 
-  // Group emails by topic (subject)
+  // Group emails into threads using RFC header chains + subject fallback
   const topics = useMemo(() => {
-    const topicGroups = groupByTopic(correspondent.emails);
+    const threads = buildThreads(correspondent.emails);
 
     // Convert to array and sort by most recent message
-    return Array.from(topicGroups.values())
+    return Array.from(threads.values())
       .sort((a, b) => {
         const dateA = a.dateRange.end || new Date(0);
         const dateB = b.dateRange.end || new Date(0);
@@ -29,31 +29,31 @@ export function ChatTopicsList({ correspondent, onBack, onSelectTopic }) {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-mail-border bg-mail-surface">
+      <div data-tauri-drag-region className="flex items-center gap-2.5 px-4 py-[13px] border-b border-mail-border bg-mail-surface">
         <button
           onClick={onBack}
-          className="p-1.5 hover:bg-mail-border rounded-lg transition-colors"
+          className="p-1 hover:bg-mail-border rounded-lg transition-colors"
         >
-          <ChevronLeft size={20} className="text-mail-text-muted" />
+          <ChevronLeft size={18} className="text-mail-text-muted" />
         </button>
 
         <div
-          className="w-10 h-10 rounded-full flex items-center justify-center text-white font-semibold flex-shrink-0"
+          className="w-7 h-7 rounded-full flex items-center justify-center text-white text-xs font-semibold flex-shrink-0"
           style={{ backgroundColor: avatarColor }}
         >
           {initials}
         </div>
 
         <div className="flex-1 min-w-0">
-          <h2 className="font-semibold text-mail-text truncate">
+          <h2 className="text-sm font-semibold text-mail-text truncate leading-tight">
             {correspondent.name}
           </h2>
-          <p className="text-xs text-mail-text-muted truncate">
+          <p className="text-[11px] text-mail-text-muted truncate leading-tight">
             {correspondent.email}
           </p>
         </div>
 
-        <div className="text-right text-xs text-mail-text-muted">
+        <div className="text-right text-[11px] text-mail-text-muted">
           <p>{correspondent.emails.length} messages</p>
           <p>{topics.length} topics</p>
         </div>
@@ -63,7 +63,7 @@ export function ChatTopicsList({ correspondent, onBack, onSelectTopic }) {
       <div className="flex-1 overflow-y-auto">
         {topics.map((topic, index) => (
           <TopicRow
-            key={topic.subject}
+            key={topic.threadId}
             topic={topic}
             onClick={() => onSelectTopic(topic)}
             index={index}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -67,12 +67,12 @@ export function Sidebar({ onAddAccount, onCompose, onOpenSettings }) {
   } = useMailStore();
 
   const { theme, toggleTheme } = useThemeStore();
-  const { getOrderedAccounts, getDisplayName, accountColors, sidebarCollapsed, toggleSidebarCollapsed } = useSettingsStore();
+  const { getOrderedAccounts, getDisplayName, accountColors, hiddenAccounts, sidebarCollapsed, toggleSidebarCollapsed } = useSettingsStore();
 
   const [expandedFolders, setExpandedFolders] = useState(new Set(['INBOX']));
   const [showErrorModal, setShowErrorModal] = useState(false);
 
-  const orderedAccounts = getOrderedAccounts(accounts);
+  const orderedAccounts = getOrderedAccounts(accounts).filter(a => !hiddenAccounts[a.id]);
   const collapsed = sidebarCollapsed;
 
   // Sort mailboxes: INBOX first, then alphabetically; children sorted alphabetically too

--- a/src/hooks/useChatBodyLoader.js
+++ b/src/hooks/useChatBodyLoader.js
@@ -1,0 +1,143 @@
+import { useEffect, useRef, useCallback, useState } from 'react';
+import { useMailStore } from '../stores/mailStore';
+import { useSettingsStore } from '../stores/settingsStore';
+import * as db from '../services/db';
+import * as api from '../services/api';
+import { ensureFreshToken } from '../services/authUtils';
+
+const CONCURRENCY = 3;
+
+/** Unique key for an email across mailboxes (UIDs are per-mailbox) */
+export const emailKey = (email) => email._fromSentFolder ? `sent-${email.uid}` : `${email.uid}`;
+
+/**
+ * Progressively loads email bodies for a list of header-only emails.
+ * Reads from / writes to the store's emailCache (same LRU cache used everywhere).
+ * Concurrency is capped at 3 to match the active pipeline's concurrency.
+ *
+ * Each MessageBubble registers a per-uid listener via registerListener().
+ * When a body loads, only that bubble re-renders — not the entire list.
+ *
+ * @param {Array} topicEmails - header-only email objects from topic.emails
+ * @returns {{ bodiesMapRef: React.RefObject<Map>, registerListener: Function }}
+ */
+export function useChatBodyLoader(topicEmails) {
+  // bodiesMap: Map<uid, { status: 'loading'|'loaded'|'error', email: object|null }>
+  const bodiesMapRef = useRef(new Map());
+  // Per-uid listener callbacks from individual MessageBubble components
+  const listenersRef = useRef(new Map());
+
+  const notifyBubble = useCallback((key) => {
+    const listener = listenersRef.current.get(key);
+    if (listener) listener();
+  }, []);
+
+  const registerListener = useCallback((key, fn) => {
+    listenersRef.current.set(key, fn);
+    return () => listenersRef.current.delete(key);
+  }, []);
+
+  // Build a stable dependency key from the topic's emails
+  const uidsKey = topicEmails?.map(e => emailKey(e)).join(',') || '';
+
+  useEffect(() => {
+    if (!topicEmails || topicEmails.length === 0) return;
+
+    let cancelled = false;
+    // Clear stale entries from previous topic
+    bodiesMapRef.current.clear();
+    const bodiesMap = bodiesMapRef.current;
+
+    const store = useMailStore.getState();
+    const cacheLimitMB = useSettingsStore.getState().cacheLimitMB;
+    const account = store.accounts.find(a => a.id === store.activeAccountId);
+    const accountId = store.activeAccountId;
+    const inboxMailbox = store.activeMailbox;
+    const sentMailbox = store.getSentMailboxPath();
+
+    // Helper: resolve the correct mailbox for an email
+    const getMailbox = (email) => email._fromSentFolder && sentMailbox ? sentMailbox : inboxMailbox;
+
+    // Pre-populate from existing emailCache (instant, no async)
+    for (const email of topicEmails) {
+      const key = emailKey(email);
+      const mailbox = getMailbox(email);
+      const cacheKey = `${accountId}-${mailbox}-${email.uid}`;
+      const cached = store.getFromCache(cacheKey);
+      if (cached) {
+        bodiesMap.set(key, { status: 'loaded', email: cached });
+      } else if (!bodiesMap.has(key) || bodiesMap.get(key).status !== 'loaded') {
+        bodiesMap.set(key, { status: 'loading', email: null });
+      }
+    }
+
+    // Collect emails still needing fetch — newest first so the latest messages load first
+    const pendingEmails = topicEmails
+      .filter(e => bodiesMap.get(emailKey(e))?.status === 'loading')
+      .reverse();
+
+    if (pendingEmails.length === 0) return;
+
+    let activeCount = 0;
+    let queueIndex = 0;
+
+    const fetchOne = async (email) => {
+      if (cancelled) return;
+      const key = emailKey(email);
+      const uid = email.uid;
+      const mailbox = getMailbox(email);
+      const cacheKey = `${accountId}-${mailbox}-${uid}`;
+
+      try {
+        let freshAccount = account;
+        if (freshAccount) {
+          try { freshAccount = await ensureFreshToken(freshAccount); } catch (_) {}
+        }
+
+        // 1. Check Maildir .eml (fast disk read)
+        let emailBody = await db.getLocalEmailLight(accountId, mailbox, uid);
+
+        // 2. IMAP fetch if not on disk
+        if (!emailBody && freshAccount) {
+          emailBody = await api.fetchEmailLight(freshAccount, uid, mailbox);
+        }
+
+        if (cancelled) return;
+
+        if (emailBody) {
+          store.addToCache(cacheKey, emailBody, cacheLimitMB);
+          bodiesMap.set(key, { status: 'loaded', email: emailBody });
+        } else {
+          bodiesMap.set(key, { status: 'error', email: null });
+        }
+      } catch (err) {
+        console.warn(`[useChatBodyLoader] Failed to load UID ${uid}:`, err);
+        if (!cancelled) {
+          bodiesMap.set(key, { status: 'error', email: null });
+        }
+      }
+
+      if (!cancelled) notifyBubble(key);
+    };
+
+    const pump = () => {
+      while (queueIndex < pendingEmails.length && !cancelled && activeCount < CONCURRENCY) {
+        const email = pendingEmails[queueIndex++];
+        activeCount++;
+        fetchOne(email).finally(() => {
+          activeCount--;
+          if (!cancelled) pump();
+        });
+      }
+    };
+
+    pump();
+
+    return () => {
+      cancelled = true;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [uidsKey]);
+
+  return { bodiesMapRef, registerListener };
+}

--- a/src/stores/settingsStore.js
+++ b/src/stores/settingsStore.js
@@ -61,6 +61,9 @@ export const useSettingsStore = create(
       // Account order (array of account IDs for drag-to-reorder)
       accountOrder: [],
 
+      // Hidden accounts { [accountId]: true } — hidden accounts don't sync and are invisible in sidebar
+      hiddenAccounts: {},
+
       // Last selected mailbox per account { [accountId]: string }
       lastMailboxPerAccount: {},
 
@@ -137,9 +140,9 @@ export const useSettingsStore = create(
         set({ cacheLimitMB: limit });
       },
 
-      // Set local cache duration (validates: 0 (all), 1, 2, 3, 6, or 12 months)
+      // Set local cache duration (validates: 0 (all), 1, 3, 6, or 12 months)
       setLocalCacheDurationMonths: (months) => {
-        const validValues = [0, 1, 2, 3, 6, 12]; // 0 = cache all emails
+        const validValues = [0, 1, 3, 6, 12]; // 0 = cache all emails
         if (validValues.includes(months)) {
           set({ localCacheDurationMonths: months });
         }
@@ -185,6 +188,18 @@ export const useSettingsStore = create(
           return { accountColors: rest };
         });
       },
+
+      // Hidden account management
+      setAccountHidden: (accountId, hidden) => {
+        set(state => {
+          if (hidden) {
+            return { hiddenAccounts: { ...state.hiddenAccounts, [accountId]: true } };
+          }
+          const { [accountId]: _, ...rest } = state.hiddenAccounts;
+          return { hiddenAccounts: rest };
+        });
+      },
+      isAccountHidden: (accountId) => !!get().hiddenAccounts[accountId],
 
       // Email sync settings
       setRefreshInterval: (minutes) => set({ refreshInterval: minutes }),
@@ -288,6 +303,7 @@ export const useSettingsStore = create(
           cacheLimitMB: 512,
           localCacheDurationMonths: 3,
           accountOrder: [],
+          hiddenAccounts: {},
           lastMailboxPerAccount: {},
           signatures: {},
           displayNames: {},

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -134,6 +134,35 @@ body {
   color: var(--mail-text-muted);
 }
 
+/* Chat bubble styles */
+:root,
+[data-theme="dark"] {
+  --chat-sent-bg: #4f46e5;
+  --chat-sent-text: #ffffff;
+  --chat-received-bg: #1e1e2e;
+  --chat-received-text: #e4e4e7;
+  --chat-received-border: #2a2a3a;
+}
+
+[data-theme="light"] {
+  --chat-sent-bg: #4338ca;
+  --chat-sent-text: #ffffff;
+  --chat-received-bg: #ffffff;
+  --chat-received-text: #1e293b;
+  --chat-received-border: #e2e8f0;
+}
+
+.chat-bubble-sent {
+  background-color: var(--chat-sent-bg);
+  color: var(--chat-sent-text);
+}
+
+.chat-bubble-received {
+  background-color: var(--chat-received-bg);
+  color: var(--chat-received-text);
+  border: 1px solid var(--chat-received-border);
+}
+
 /* Custom checkbox */
 .custom-checkbox {
   appearance: none;

--- a/tests/unit/chatView.test.js
+++ b/tests/unit/chatView.test.js
@@ -1,0 +1,871 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getCorrespondent,
+  groupByCorrespondent,
+  normalizeSubject,
+  groupByTopic,
+  getCleanMessageBody,
+  htmlToPlainText,
+  stripSignature,
+  stripQuotedContent,
+  isFromUser,
+  getPreview,
+  isDifferentDay,
+  formatDateSeparator,
+  formatMessageTime,
+  formatRelativeTime
+} from '../../src/utils/emailParser.js';
+
+// ── Helper: build email objects ─────────────────────────────────────
+
+function makeEmail(overrides = {}) {
+  return {
+    uid: 1,
+    from: { address: 'alice@example.com', name: 'Alice' },
+    to: [{ address: 'me@example.com', name: 'Me' }],
+    subject: 'Test Subject',
+    date: '2024-06-15T12:00:00Z',
+    flags: [],
+    ...overrides,
+  };
+}
+
+const USER = 'me@example.com';
+
+// ═════════════════════════════════════════════════════════════════════
+// Chat View: Correspondent Grouping (real-world patterns)
+// ═════════════════════════════════════════════════════════════════════
+
+describe('groupByCorrespondent — real-world patterns', () => {
+  it('groups a bidirectional thread into one correspondent', () => {
+    // Pattern from real data: tomas@sdatransport.eu ↔ eda@ntgroad.se
+    const emails = [
+      makeEmail({ uid: 1, from: { address: 'eda@ntgroad.se', name: 'Eda' }, to: [{ address: USER }], subject: 'MYY046/ZZM51Z', date: '2024-01-10T08:00:00Z' }),
+      makeEmail({ uid: 2, from: { address: USER, name: 'Me' }, to: [{ address: 'eda@ntgroad.se', name: 'Eda' }], subject: 'RE: MYY046/ZZM51Z', date: '2024-01-10T09:00:00Z' }),
+      makeEmail({ uid: 3, from: { address: 'eda@ntgroad.se', name: 'Eda' }, to: [{ address: USER }], subject: 'RE: MYY046/ZZM51Z', date: '2024-01-10T10:00:00Z' }),
+      makeEmail({ uid: 4, from: { address: USER, name: 'Me' }, to: [{ address: 'eda@ntgroad.se', name: 'Eda' }], subject: 'RE: MYY046/ZZM51Z', date: '2024-01-10T11:00:00Z' }),
+    ];
+    const groups = groupByCorrespondent(emails, USER);
+    expect(groups.size).toBe(1);
+    expect(groups.get('eda@ntgroad.se').emails).toHaveLength(4);
+  });
+
+  it('handles multiple correspondents sending about the same subject', () => {
+    // Pattern from real data: MYY046/YDD848 from lsc@, dla@, mko@ — all to tomas@
+    const emails = [
+      makeEmail({ uid: 1, from: { address: 'lsc@ntgroad.se', name: 'LSC' }, to: [{ address: USER }], subject: 'FW: MYY046/YDD848' }),
+      makeEmail({ uid: 2, from: { address: 'dla@ntgroad.se', name: 'DLA' }, to: [{ address: USER }], subject: 'RE: MYY046/YDD848' }),
+      makeEmail({ uid: 3, from: { address: 'mko@ntgroad.se', name: 'MKO' }, to: [{ address: USER }], subject: 'RE: MYY046/YDD848' }),
+    ];
+    const groups = groupByCorrespondent(emails, USER);
+    // Each sender becomes their own correspondent group
+    expect(groups.size).toBe(3);
+    expect(groups.has('lsc@ntgroad.se')).toBe(true);
+    expect(groups.has('dla@ntgroad.se')).toBe(true);
+    expect(groups.has('mko@ntgroad.se')).toBe(true);
+  });
+
+  it('handles emails with multiple recipients (CC pattern)', () => {
+    // Real pattern: email sent to tomas@ with CC to multiple others
+    const emails = [
+      makeEmail({
+        uid: 1,
+        from: { address: 'dmu@ntgroad.se', name: 'DMU' },
+        to: [
+          { address: USER },
+          { address: 'riv@ntgroad.se' },
+          { address: 'rda@ntgroad.se' },
+        ],
+        cc: [{ address: 'tja@ntgroad.se' }],
+      }),
+    ];
+    const groups = groupByCorrespondent(emails, USER);
+    expect(groups.size).toBe(1);
+    expect(groups.has('dmu@ntgroad.se')).toBe(true);
+  });
+
+  it('handles sender with special characters in display name', () => {
+    // Real pattern: UAB „Everwest" (Lithuanian quotation marks)
+    const emails = [
+      makeEmail({
+        uid: 1,
+        from: { address: 'info@everwest.lt', name: 'UAB „Everwest"' },
+        to: [{ address: USER }],
+      }),
+    ];
+    const groups = groupByCorrespondent(emails, USER);
+    const group = groups.get('info@everwest.lt');
+    expect(group.name).toBe('UAB „Everwest"');
+  });
+
+  it('handles self-sent emails (from and to are the same user)', () => {
+    const emails = [
+      makeEmail({
+        uid: 1,
+        from: { address: USER, name: 'Me' },
+        to: [{ address: USER, name: 'Me' }],
+        subject: 'Note to self',
+      }),
+    ];
+    const groups = groupByCorrespondent(emails, USER);
+    // Correspondent is the "to" (which is also user)
+    expect(groups.size).toBe(1);
+    expect(groups.has(USER)).toBe(true);
+  });
+
+  it('handles 17000+ emails without crashing', () => {
+    // Simulate scale from real data (cc15df7f account had 17020 emails)
+    const emails = Array.from({ length: 500 }, (_, i) => makeEmail({
+      uid: i + 1,
+      from: { address: `sender${i % 50}@example.com`, name: `Sender ${i % 50}` },
+      to: [{ address: USER }],
+      subject: `Thread ${i % 20}`,
+      date: new Date(2024, 0, 1, 0, i).toISOString(),
+    }));
+    const groups = groupByCorrespondent(emails, USER);
+    expect(groups.size).toBe(50);
+    // Each sender gets 10 emails (500 / 50 senders)
+    for (const group of groups.values()) {
+      expect(group.emails).toHaveLength(10);
+    }
+  });
+
+  it('handles emails with empty from address', () => {
+    const emails = [
+      makeEmail({ uid: 1, from: { address: '', name: '' }, to: [{ address: USER }] }),
+    ];
+    const groups = groupByCorrespondent(emails, USER);
+    // Empty key is skipped
+    expect(groups.size).toBe(0);
+  });
+
+  it('handles emails with no to field (empty key skipped)', () => {
+    const emails = [
+      makeEmail({ uid: 1, from: { address: USER }, to: undefined }),
+    ];
+    const groups = groupByCorrespondent(emails, USER);
+    // When from=user and to is undefined, correspondent key is '' which is skipped
+    expect(groups.size).toBe(0);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// Chat View: Topic Grouping
+// ═════════════════════════════════════════════════════════════════════
+
+describe('groupByTopic — real-world patterns', () => {
+  it('groups FW: and RE: variants of same subject', () => {
+    // Real pattern from MYY046/YDD848
+    const emails = [
+      makeEmail({ uid: 1, subject: 'MYY046/YDD848', date: '2024-01-10T08:00:00Z' }),
+      makeEmail({ uid: 2, subject: 'FW: MYY046/YDD848', date: '2024-01-10T09:00:00Z' }),
+      makeEmail({ uid: 3, subject: 'RE: MYY046/YDD848', date: '2024-01-10T10:00:00Z' }),
+      makeEmail({ uid: 4, subject: 'Re: MYY046/YDD848', date: '2024-01-10T11:00:00Z' }),
+    ];
+    const topics = groupByTopic(emails);
+    expect(topics.size).toBe(1);
+    expect(topics.get('MYY046/YDD848').emails).toHaveLength(4);
+  });
+
+  it('groups duplicate subjects (same email sent multiple times)', () => {
+    // Real pattern: "Shipping confirmation: Order #98234" sent 7 times
+    const emails = Array.from({ length: 7 }, (_, i) => makeEmail({
+      uid: i + 1,
+      subject: 'Shipping confirmation: Order #98234',
+      date: new Date(2024, 0, 15, 10 + i).toISOString(),
+    }));
+    const topics = groupByTopic(emails);
+    expect(topics.size).toBe(1);
+    expect(topics.get('Shipping confirmation: Order #98234').emails).toHaveLength(7);
+  });
+
+  it('handles empty subject', () => {
+    // Real data: 68 emails with empty subjects
+    const emails = [
+      makeEmail({ uid: 1, subject: '', date: '2024-01-10T08:00:00Z' }),
+      makeEmail({ uid: 2, subject: '', date: '2024-01-10T09:00:00Z' }),
+      makeEmail({ uid: 3, subject: 'Re: ', date: '2024-01-10T10:00:00Z' }),
+    ];
+    const topics = groupByTopic(emails);
+    // All normalize to "(No subject)"
+    expect(topics.size).toBe(1);
+    expect(topics.get('(No subject)').emails).toHaveLength(3);
+  });
+
+  it('handles null subject', () => {
+    const emails = [
+      makeEmail({ uid: 1, subject: null }),
+      makeEmail({ uid: 2, subject: undefined }),
+    ];
+    const topics = groupByTopic(emails);
+    expect(topics.size).toBe(1);
+    expect(topics.get('(No subject)').emails).toHaveLength(2);
+  });
+
+  it('handles very long subjects', () => {
+    // Real data: longest subject was 165 chars
+    const longSubject = 'A'.repeat(165);
+    const emails = [
+      makeEmail({ uid: 1, subject: longSubject }),
+      makeEmail({ uid: 2, subject: `Re: ${longSubject}` }),
+    ];
+    const topics = groupByTopic(emails);
+    expect(topics.size).toBe(1);
+    expect(topics.get(longSubject).emails).toHaveLength(2);
+  });
+
+  it('handles subjects with special characters', () => {
+    // Real patterns: subjects with slashes, arrows, parens
+    const emails = [
+      makeEmail({ uid: 1, subject: 'UAB SDA Transport - MUB348 // PAT74K --> YJA351' }),
+      makeEmail({ uid: 2, subject: 'RE: UAB SDA Transport - MUB348 // PAT74K --> YJA351' }),
+    ];
+    const topics = groupByTopic(emails);
+    expect(topics.size).toBe(1);
+  });
+
+  it('separates unrelated subjects that start similarly', () => {
+    const emails = [
+      makeEmail({ uid: 1, subject: 'MYY046/YDD848' }),
+      makeEmail({ uid: 2, subject: 'MYY046/YCX538' }),
+      makeEmail({ uid: 3, subject: 'MYY046/ZZM51Z' }),
+    ];
+    const topics = groupByTopic(emails);
+    expect(topics.size).toBe(3);
+  });
+
+  it('preserves chronological order within topic', () => {
+    const emails = [
+      makeEmail({ uid: 3, subject: 'RE: Topic', date: '2024-01-12T10:00:00Z' }),
+      makeEmail({ uid: 1, subject: 'Topic', date: '2024-01-10T10:00:00Z' }),
+      makeEmail({ uid: 2, subject: 'RE: Topic', date: '2024-01-11T10:00:00Z' }),
+    ];
+    const topics = groupByTopic(emails);
+    const topic = topics.get('Topic');
+    expect(topic.emails[0].uid).toBe(1);
+    expect(topic.emails[1].uid).toBe(2);
+    expect(topic.emails[2].uid).toBe(3);
+  });
+
+  it('tracks date range across topic', () => {
+    const emails = [
+      makeEmail({ uid: 1, subject: 'Weekly digest: Engineering updates', date: '2024-01-01T10:00:00Z' }),
+      makeEmail({ uid: 2, subject: 'Weekly digest: Engineering updates', date: '2024-01-08T10:00:00Z' }),
+      makeEmail({ uid: 3, subject: 'Weekly digest: Engineering updates', date: '2024-01-15T10:00:00Z' }),
+    ];
+    const topics = groupByTopic(emails);
+    const topic = topics.get('Weekly digest: Engineering updates');
+    expect(topic.dateRange.start).toEqual(new Date('2024-01-01T10:00:00Z'));
+    expect(topic.dateRange.end).toEqual(new Date('2024-01-15T10:00:00Z'));
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// Chat View: normalizeSubject edge cases
+// ═════════════════════════════════════════════════════════════════════
+
+describe('normalizeSubject — extreme cases', () => {
+  it('strips mixed-case Re/Fwd prefixes', () => {
+    expect(normalizeSubject('rE: Hello')).toBe('Hello');
+    expect(normalizeSubject('fWd: Hello')).toBe('Hello');
+  });
+
+  it('strips triple-nested Re:', () => {
+    // normalizeSubject now strips all levels of Re:/Fwd: prefixes
+    expect(normalizeSubject('Re: Re: Re: Hello')).toBe('Hello');
+  });
+
+  it('handles "Re: " with trailing spaces', () => {
+    expect(normalizeSubject('Re:   Lots of spaces')).toBe('Lots of spaces');
+  });
+
+  it('handles subject that is just "Re:"', () => {
+    expect(normalizeSubject('Re:')).toBe('(No subject)');
+  });
+
+  it('handles subject that is just whitespace after stripping', () => {
+    expect(normalizeSubject('Re:   ')).toBe('(No subject)');
+  });
+
+  it('preserves colons in non-prefix position', () => {
+    expect(normalizeSubject('Meeting: 3pm tomorrow')).toBe('Meeting: 3pm tomorrow');
+  });
+
+  it('handles Re[N]: pattern', () => {
+    expect(normalizeSubject('Re[5]: Discussion')).toBe('Discussion');
+  });
+
+  it('handles FW: (Outlook style)', () => {
+    expect(normalizeSubject('FW: Forwarded message')).toBe('Forwarded message');
+  });
+
+  it('handles subject with unicode characters', () => {
+    expect(normalizeSubject('Re: Nauji skelbimai: Namai Palangoje')).toBe('Nauji skelbimai: Namai Palangoje');
+  });
+
+  it('handles subject with emojis', () => {
+    expect(normalizeSubject('Re: 🎉 Release notes')).toBe('🎉 Release notes');
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// Chat View: getCleanMessageBody edge cases
+// ═════════════════════════════════════════════════════════════════════
+
+describe('getCleanMessageBody — extreme cases', () => {
+  it('handles header-only email (no text, no html)', () => {
+    // This is the actual bug case — emails from the header cache
+    const email = {
+      uid: 123,
+      from: { address: 'alice@example.com' },
+      to: [{ address: 'me@example.com' }],
+      subject: 'Test',
+      date: '2024-01-15T10:00:00Z',
+      flags: [],
+      // No text, textBody, or html fields
+    };
+    const result = getCleanMessageBody(email);
+    expect(result).toBe('');
+  });
+
+  it('handles email with undefined text fields explicitly set', () => {
+    const email = { text: undefined, textBody: undefined, html: undefined };
+    expect(getCleanMessageBody(email)).toBe('');
+  });
+
+  it('handles email with null text fields', () => {
+    const email = { text: null, textBody: null, html: null };
+    expect(getCleanMessageBody(email)).toBe('');
+  });
+
+  it('handles email with empty string text', () => {
+    const email = { text: '' };
+    expect(getCleanMessageBody(email)).toBe('');
+  });
+
+  it('handles email with whitespace-only text', () => {
+    const email = { text: '   \n\n   \t  ' };
+    expect(getCleanMessageBody(email)).toBe('');
+  });
+
+  it('handles HTML-only email (extracts text from HTML)', () => {
+    const email = { html: '<div><p>Hello from HTML</p></div>' };
+    const result = getCleanMessageBody(email);
+    expect(result).toContain('Hello from HTML');
+  });
+
+  it('strips quoted content from deeply nested Outlook-style reply', () => {
+    const text = `Thanks for the update.
+
+-----Original Message-----
+From: Alice Smith
+Sent: Monday, January 15, 2024
+To: Me
+Subject: RE: Project
+
+Previous message content here`;
+    const email = { text };
+    const result = getCleanMessageBody(email);
+    expect(result).toBe('Thanks for the update.');
+  });
+
+  it('strips Gmail-style quoted content', () => {
+    const text = `Got it, thanks!
+
+On Mon, Jan 15, 2024 at 10:00 AM Alice <alice@example.com> wrote:
+> Here is the original message
+> with multiple lines`;
+    const email = { text };
+    const result = getCleanMessageBody(email);
+    expect(result).toBe('Got it, thanks!');
+  });
+
+  it('handles email with only a signature', () => {
+    const text = '-- \nJohn Doe\nCEO, Company Inc.';
+    const email = { text };
+    expect(getCleanMessageBody(email)).toBe('');
+  });
+
+  it('handles email with HTML that has only images (no text)', () => {
+    const email = { html: '<img src="cid:image001.png" />' };
+    const result = getCleanMessageBody(email);
+    expect(result).toBe('');
+  });
+
+  it('handles email with HTML containing only a table', () => {
+    const email = { html: '<table><tr><td>Cell 1</td><td>Cell 2</td></tr></table>' };
+    const result = getCleanMessageBody(email);
+    expect(result).toContain('Cell 1');
+    expect(result).toContain('Cell 2');
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// Chat View: htmlToPlainText extreme cases
+// ═════════════════════════════════════════════════════════════════════
+
+describe('htmlToPlainText — extreme cases', () => {
+  it('handles deeply nested HTML', () => {
+    const html = '<div><div><div><div><p>Deep content</p></div></div></div></div>';
+    expect(htmlToPlainText(html)).toContain('Deep content');
+  });
+
+  it('handles HTML with inline styles', () => {
+    const html = '<p style="color: red; font-size: 14px;">Styled text</p>';
+    const result = htmlToPlainText(html);
+    expect(result).toContain('Styled text');
+    expect(result).not.toContain('color');
+  });
+
+  it('handles HTML with data attributes', () => {
+    const html = '<div data-custom="value" data-id="123">Content</div>';
+    expect(htmlToPlainText(html)).toContain('Content');
+  });
+
+  it('handles HTML with self-closing tags', () => {
+    const html = 'Before<hr/>After<br/>End';
+    const result = htmlToPlainText(html);
+    expect(result).toContain('Before');
+    expect(result).toContain('After');
+    expect(result).toContain('End');
+  });
+
+  it('handles malformed HTML gracefully', () => {
+    const html = '<p>Unclosed paragraph<div>Mixed tags</p></div>';
+    const result = htmlToPlainText(html);
+    expect(result).toContain('Unclosed paragraph');
+    expect(result).toContain('Mixed tags');
+  });
+
+  it('handles HTML with comments', () => {
+    const html = '<!-- comment -->Visible<!-- another comment --> text';
+    const result = htmlToPlainText(html);
+    expect(result).toContain('Visible');
+    expect(result).toContain('text');
+    expect(result).not.toContain('comment');
+  });
+
+  it('handles HTML email with tracking pixel', () => {
+    const html = '<p>Content</p><img src="https://tracker.com/pixel.gif" width="1" height="1" />';
+    const result = htmlToPlainText(html);
+    expect(result).toContain('Content');
+    expect(result).not.toContain('tracker');
+  });
+
+  it('handles HTML with numeric entities', () => {
+    const html = '&#169; 2024 Company';
+    const result = htmlToPlainText(html);
+    // Numeric entities may or may not be decoded, but should not crash
+    expect(result).toContain('2024 Company');
+  });
+
+  it('handles email with massive HTML (newsletter-style)', () => {
+    // Simulate a large HTML email with tables, images, many divs
+    const rows = Array.from({ length: 100 }, (_, i) =>
+      `<tr><td style="padding:10px"><p>Row ${i}</p></td></tr>`
+    ).join('');
+    const html = `<table width="600">${rows}</table>`;
+    const result = htmlToPlainText(html);
+    expect(result).toContain('Row 0');
+    expect(result).toContain('Row 99');
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// Chat View: stripSignature extreme cases
+// ═════════════════════════════════════════════════════════════════════
+
+describe('stripSignature — extreme cases', () => {
+  it('strips "Sent from Yahoo Mail"', () => {
+    const text = 'Message\n\nSent from Yahoo Mail';
+    expect(stripSignature(text)).toBe('Message');
+  });
+
+  it('strips "Sent from AOL Mobile Mail"', () => {
+    const text = 'Message\n\nSent from AOL Mobile Mail';
+    expect(stripSignature(text)).toBe('Message');
+  });
+
+  it('strips underscore-line signature delimiter', () => {
+    const text = 'Message body\n___\nSignature here';
+    expect(stripSignature(text)).toBe('Message body');
+  });
+
+  it('strips dash-line signature delimiter', () => {
+    const text = 'Message body\n---\nSignature here';
+    expect(stripSignature(text)).toBe('Message body');
+  });
+
+  it('handles "Best Regards," sign-off in long message', () => {
+    const body = 'A'.repeat(200);
+    const text = `${body}\nBest Regards,\nJohn`;
+    const result = stripSignature(text);
+    expect(result).not.toContain('Best Regards');
+  });
+
+  it('handles "Kind Regards," sign-off', () => {
+    const body = 'A'.repeat(200);
+    const text = `${body}\nKind Regards,\nJohn`;
+    expect(stripSignature(text)).not.toContain('Kind Regards');
+  });
+
+  it('does not strip "Thanks" in the middle of a message', () => {
+    const text = 'Thanks for the help with the project. I appreciate it.';
+    expect(stripSignature(text)).toBe(text);
+  });
+
+  it('handles message that is entirely a signature', () => {
+    const text = '-- \nJohn Doe';
+    expect(stripSignature(text)).toBe('');
+  });
+
+  it('handles multiple signature delimiters — uses earliest', () => {
+    const text = 'Message\n-- \nFirst sig\n---\nSecond sig';
+    expect(stripSignature(text)).toBe('Message');
+  });
+
+  it('handles "Sent from my Samsung" variant', () => {
+    const text = 'Quick reply\n\nSent from my Samsung Galaxy';
+    expect(stripSignature(text)).toBe('Quick reply');
+  });
+
+  it('handles "Get Outlook for Mac"', () => {
+    const text = 'Reply here\n\nGet Outlook for Mac';
+    expect(stripSignature(text)).toBe('Reply here');
+  });
+
+  it('handles "Sent from Mail for Windows"', () => {
+    const text = 'My reply\n\nSent from Mail for Windows';
+    expect(stripSignature(text)).toBe('My reply');
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// Chat View: stripQuotedContent extreme cases
+// ═════════════════════════════════════════════════════════════════════
+
+describe('stripQuotedContent — extreme cases', () => {
+  it('handles multiple levels of > quoting', () => {
+    const text = 'My reply\n> First level\n>> Second level\n>>> Third level';
+    const result = stripQuotedContent(text);
+    expect(result).toBe('My reply');
+  });
+
+  it('handles interleaved quoted and non-quoted content', () => {
+    // When someone replies inline
+    const text = 'My comment\n> Their point\nMy response\n> Another point';
+    const result = stripQuotedContent(text);
+    // Should keep non-quoted lines
+    expect(result).toContain('My comment');
+    expect(result).toContain('My response');
+    expect(result).not.toContain('Their point');
+  });
+
+  it('handles Outlook header-style quoting', () => {
+    const text = `Reply here
+
+From: Alice Smith
+Sent: Monday, January 15, 2024 10:00 AM
+To: Bob Jones
+Subject: Original subject
+
+Original message body`;
+    const result = stripQuotedContent(text);
+    expect(result).toBe('Reply here');
+  });
+
+  it('handles underscore + From quoting', () => {
+    // The QUOTE_PATTERNS regex is /^_{5,}\nFrom:\s*/im which needs
+    // underscore line immediately followed by From: on next line
+    const text = `My reply
+_____
+From: someone@example.com
+Sent: Today
+To: me@example.com`;
+    const result = stripQuotedContent(text);
+    // The underscore regex matches `_{5,}\nFrom:` as a single pattern,
+    // but the actual text has `_____\n` then `From:` on new line —
+    // the underscores are caught by the stripSignature `_{3,}` pattern
+    // (not stripQuotedContent). Result keeps underscores but strips From: quoted lines.
+    expect(result).toContain('My reply');
+    expect(result).not.toContain('someone@example.com');
+  });
+
+  it('handles empty quoted content', () => {
+    const text = 'My reply\n>\n>';
+    const result = stripQuotedContent(text);
+    expect(result).toBe('My reply');
+  });
+
+  it('handles email with only quoted content', () => {
+    const text = '> All quoted\n> No original content';
+    const result = stripQuotedContent(text);
+    expect(result).toBe('');
+  });
+
+  it('preserves code blocks that look like quotes', () => {
+    // Lines with > that are part of code, not quotes
+    const text = 'Code example:\n\nif (x > 5) { return true; }';
+    const result = stripQuotedContent(text);
+    // The > is in the middle of a line, not at start, so should be preserved
+    expect(result).toContain('if (x > 5)');
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// Chat View: isFromUser edge cases
+// ═════════════════════════════════════════════════════════════════════
+
+describe('isFromUser — edge cases', () => {
+  it('handles email alias (+ addressing)', () => {
+    // user+tag@example.com is technically different from user@example.com
+    const email = { from: { address: 'me+newsletter@example.com' } };
+    expect(isFromUser(email, 'me@example.com')).toBe(false);
+  });
+
+  it('handles from address with whitespace', () => {
+    const email = { from: { address: ' me@example.com ' } };
+    // Current implementation doesn't trim, so this won't match
+    expect(isFromUser(email, 'me@example.com')).toBe(false);
+  });
+
+  it('handles missing from.address', () => {
+    const email = { from: { name: 'Alice' } };
+    expect(isFromUser(email, 'me@example.com')).toBe(false);
+  });
+
+  it('handles from as null', () => {
+    const email = { from: null };
+    expect(isFromUser(email, 'me@example.com')).toBe(false);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// Chat View: Combined flow — full conversation lifecycle
+// ═════════════════════════════════════════════════════════════════════
+
+describe('full conversation flow', () => {
+  it('groups, topics, and cleans a realistic email thread', () => {
+    const userEmail = 'tomas@sdatransport.eu';
+    const emails = [
+      makeEmail({
+        uid: 100,
+        from: { address: 'export.sweu@ntgroad.se', name: 'NTG Export' },
+        to: [{ address: userEmail }],
+        subject: 'MYY046/ZZM51Z',
+        date: '2024-01-10T08:00:00Z',
+        text: 'Please confirm the order.\n\n-- \nNTG Export Team',
+      }),
+      makeEmail({
+        uid: 101,
+        from: { address: userEmail, name: 'Tomas' },
+        to: [{ address: 'export.sweu@ntgroad.se' }],
+        subject: 'RE: MYY046/ZZM51Z',
+        date: '2024-01-10T09:00:00Z',
+        text: 'Confirmed.\n\nOn Wed, Jan 10, 2024, NTG Export wrote:\n> Please confirm the order.',
+      }),
+      makeEmail({
+        uid: 102,
+        from: { address: 'export.sweu@ntgroad.se', name: 'NTG Export' },
+        to: [{ address: userEmail }],
+        subject: 'RE: MYY046/ZZM51Z',
+        date: '2024-01-10T10:00:00Z',
+        text: 'Thank you. Shipment scheduled for Jan 15.\n\nBest Regards,\nNTG',
+      }),
+    ];
+
+    // Step 1: Group by correspondent
+    const groups = groupByCorrespondent(emails, userEmail);
+    expect(groups.size).toBe(1);
+    const group = groups.get('export.sweu@ntgroad.se');
+    expect(group.emails).toHaveLength(3);
+    expect(group.name).toBe('NTG Export');
+
+    // Step 2: Group by topic within correspondent
+    const topics = groupByTopic(group.emails);
+    expect(topics.size).toBe(1);
+    const topic = topics.get('MYY046/ZZM51Z');
+    expect(topic.emails).toHaveLength(3);
+
+    // Step 3: Clean message bodies
+    const bodies = topic.emails.map(e => getCleanMessageBody(e));
+    expect(bodies[0]).toBe('Please confirm the order.');
+    expect(bodies[1]).toBe('Confirmed.');
+    // Third email has a sign-off but message is short enough it might not strip
+    expect(bodies[2]).toContain('Thank you');
+
+    // Step 4: Verify ordering
+    expect(isFromUser(topic.emails[0], userEmail)).toBe(false);
+    expect(isFromUser(topic.emails[1], userEmail)).toBe(true);
+    expect(isFromUser(topic.emails[2], userEmail)).toBe(false);
+  });
+
+  it('handles header-only emails gracefully in full flow', () => {
+    // This simulates what actually happens in the app — emails from cache have no body
+    const userEmail = 'me@example.com';
+    const headerOnlyEmails = [
+      {
+        uid: 1, from: { address: 'alice@example.com', name: 'Alice' },
+        to: [{ address: userEmail }], subject: 'Hello',
+        date: '2024-01-15T10:00:00Z', flags: [],
+      },
+      {
+        uid: 2, from: { address: userEmail, name: 'Me' },
+        to: [{ address: 'alice@example.com' }], subject: 'Re: Hello',
+        date: '2024-01-15T11:00:00Z', flags: ['\\Seen'],
+      },
+    ];
+
+    const groups = groupByCorrespondent(headerOnlyEmails, userEmail);
+    expect(groups.size).toBe(1);
+
+    const topics = groupByTopic(groups.get('alice@example.com').emails);
+    expect(topics.size).toBe(1);
+
+    // Bodies should be empty — not crash
+    const topic = topics.get('Hello');
+    for (const email of topic.emails) {
+      const body = getCleanMessageBody(email);
+      expect(body).toBe('');
+      // hasDisplayableContent check (same as ChatBubbleView)
+      const hasHtml = !!email.html;
+      const hasDisplayableContent = hasHtml || (body && body.trim().length > 0);
+      expect(hasDisplayableContent).toBeFalsy();
+    }
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// Chat View: Date formatting edge cases
+// ═════════════════════════════════════════════════════════════════════
+
+describe('formatMessageTime', () => {
+  it('formats a valid date', () => {
+    const result = formatMessageTime('2024-06-15T14:30:00Z');
+    // Should contain time components (exact format depends on locale)
+    expect(result).toBeTruthy();
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('handles midnight', () => {
+    const result = formatMessageTime('2024-06-15T00:00:00Z');
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('isDifferentDay — edge cases', () => {
+  it('handles dates just before and after midnight UTC', () => {
+    // These might be same day depending on timezone
+    const result = isDifferentDay('2024-01-15T23:59:59Z', '2024-01-16T00:00:01Z');
+    // In most timezones these are different days (or same day depending on offset)
+    // We just verify it doesn't crash
+    expect(typeof result).toBe('boolean');
+  });
+
+  it('handles invalid date strings', () => {
+    const result = isDifferentDay('not-a-date', 'also-not-a-date');
+    // Invalid Date.toDateString() returns "Invalid Date" for both
+    expect(result).toBe(false);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// Chat View: getPreview extreme cases
+// ═════════════════════════════════════════════════════════════════════
+
+describe('getPreview — extreme cases', () => {
+  it('handles text with only whitespace', () => {
+    const email = { text: '   \n\n\t  ' };
+    expect(getPreview(email)).toBe('');
+  });
+
+  it('handles text with many newlines', () => {
+    const email = { text: 'Hello\n\n\n\n\n\nWorld' };
+    expect(getPreview(email)).toBe('Hello World');
+  });
+
+  it('handles unicode text', () => {
+    const email = { text: 'Nauji skelbimai: Namai Palangoje' };
+    expect(getPreview(email)).toBe('Nauji skelbimai: Namai Palangoje');
+  });
+
+  it('handles emoji in text', () => {
+    const email = { text: '🎉 Great news!' };
+    expect(getPreview(email)).toBe('🎉 Great news!');
+  });
+
+  it('priority order: text > textBody > snippet', () => {
+    const email = {
+      text: 'Primary text',
+      textBody: 'Fallback body',
+      snippet: 'Snippet'
+    };
+    expect(getPreview(email)).toBe('Primary text');
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// Chat View: Scale and stress tests
+// ═════════════════════════════════════════════════════════════════════
+
+describe('scale and stress', () => {
+  it('groupByCorrespondent handles 1000 emails from 100 senders', () => {
+    const emails = Array.from({ length: 1000 }, (_, i) => makeEmail({
+      uid: i + 1,
+      from: { address: `sender${i % 100}@example.com`, name: `Sender ${i % 100}` },
+      to: [{ address: USER }],
+      subject: `Thread ${i % 30}`,
+      date: new Date(2024, 0, 1, 0, i).toISOString(),
+    }));
+
+    const start = performance.now();
+    const groups = groupByCorrespondent(emails, USER);
+    const elapsed = performance.now() - start;
+
+    expect(groups.size).toBe(100);
+    expect(elapsed).toBeLessThan(500); // Should be fast
+  });
+
+  it('groupByTopic handles 500 emails with 50 topics', () => {
+    const emails = Array.from({ length: 500 }, (_, i) => makeEmail({
+      uid: i + 1,
+      subject: `${i % 3 === 0 ? 'Re: ' : ''}Topic ${i % 50}`,
+      date: new Date(2024, 0, 1, 0, i).toISOString(),
+    }));
+
+    const start = performance.now();
+    const topics = groupByTopic(emails);
+    const elapsed = performance.now() - start;
+
+    expect(topics.size).toBe(50);
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it('getCleanMessageBody handles very large text (10KB)', () => {
+    const text = 'Hello\n'.repeat(2000) + '\nOn Mon wrote:\n> quoted';
+    const email = { text };
+
+    const start = performance.now();
+    const result = getCleanMessageBody(email);
+    const elapsed = performance.now() - start;
+
+    expect(result).toContain('Hello');
+    expect(result).not.toContain('quoted');
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it('htmlToPlainText handles large HTML (50KB newsletter)', () => {
+    const rows = Array.from({ length: 500 }, (_, i) =>
+      `<tr><td style="padding:10px;color:#333"><p>Newsletter item ${i} with <a href="https://example.com/${i}">link</a></p></td></tr>`
+    ).join('');
+    const html = `<html><head><style>body{margin:0}</style></head><body><table width="600">${rows}</table></body></html>`;
+
+    const start = performance.now();
+    const result = htmlToPlainText(html);
+    const elapsed = performance.now() - start;
+
+    expect(result).toContain('Newsletter item 0');
+    expect(result).toContain('Newsletter item 499');
+    expect(elapsed).toBeLessThan(1000);
+  });
+});

--- a/website/blog/gmail-oauth2.html
+++ b/website/blog/gmail-oauth2.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Blog - MailVault</title>
-  <meta name="description" content="Behind the scenes of building MailVault. Development updates, technical deep dives, and release notes.">
+  <title>Adding Gmail OAuth2: One Flow, Two Providers - MailVault Blog</title>
+  <meta name="description" content="How we added Gmail OAuth2 to MailVault by making the existing Microsoft OAuth2 flow provider-agnostic.">
   <meta name="robots" content="index, follow">
-  <link rel="canonical" href="https://mailvaultapp.com/blog.html">
+  <link rel="canonical" href="https://mailvaultapp.com/blog/gmail-oauth2.html">
   <meta name="theme-color" content="#6366f1">
 
   <!-- Open Graph -->
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://mailvaultapp.com/blog.html">
-  <meta property="og:title" content="Blog - MailVault">
-  <meta property="og:description" content="Behind the scenes of building MailVault. Development updates, technical deep dives, and release notes.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://mailvaultapp.com/blog/gmail-oauth2.html">
+  <meta property="og:title" content="Adding Gmail OAuth2: One Flow, Two Providers - MailVault Blog">
+  <meta property="og:description" content="How we added Gmail OAuth2 to MailVault by making the existing Microsoft OAuth2 flow provider-agnostic.">
   <meta property="og:image" content="https://mailvaultapp.com/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -21,14 +21,14 @@
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Blog - MailVault">
-  <meta name="twitter:description" content="Behind the scenes of building MailVault. Development updates, technical deep dives, and release notes.">
+  <meta name="twitter:title" content="Adding Gmail OAuth2: One Flow, Two Providers - MailVault Blog">
+  <meta name="twitter:description" content="How we added Gmail OAuth2 to MailVault by making the existing Microsoft OAuth2 flow provider-agnostic.">
   <meta name="twitter:image" content="https://mailvaultapp.com/og-image.png">
   <meta name="twitter:site" content="@GraphicMeat">
 
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -70,6 +70,30 @@
       background: rgba(0, 0, 0, 0.2);
       border: 1px solid rgba(255, 255, 255, 0.05);
     }
+    article pre {
+      background: #1e293b;
+      color: #e2e8f0;
+      padding: 1rem 1.25rem;
+      border-radius: 0.75rem;
+      overflow-x: auto;
+      font-size: 0.875rem;
+      line-height: 1.7;
+    }
+    .dark article pre {
+      background: #0f172a;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+    }
+    article code:not(pre code) {
+      background: rgba(99, 102, 241, 0.1);
+      color: #6366f1;
+      padding: 0.15rem 0.4rem;
+      border-radius: 0.25rem;
+      font-size: 0.875em;
+    }
+    .dark article code:not(pre code) {
+      background: rgba(99, 102, 241, 0.2);
+      color: #a5b4fc;
+    }
   </style>
 </head>
 
@@ -80,7 +104,7 @@
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex items-center justify-between h-16">
         <a href="/" class="flex items-center gap-3">
-          <img src="icon-128.png" alt="MailVault logo" class="w-8 h-8 rounded-lg">
+          <img src="/icon-128.png" alt="MailVault logo" class="w-8 h-8 rounded-lg">
           <span class="font-bold text-xl">Mail<span class="text-primary-500">Vault</span></span>
         </a>
 
@@ -101,7 +125,6 @@
           <a href="https://github.com/GraphicMeat/mail-vault-app/releases/latest" target="_blank" class="hidden sm:inline-flex gradient-bg text-white px-4 py-2 rounded-lg font-medium hover:opacity-90 transition-opacity">
             Download
           </a>
-          <!-- Mobile menu button -->
           <button id="mobile-menu-btn" class="md:hidden p-2 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path id="menu-icon-open" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
@@ -111,7 +134,6 @@
         </div>
       </div>
 
-      <!-- Mobile menu -->
       <div id="mobile-menu" class="hidden md:hidden pb-4">
         <div class="flex flex-col gap-2 pt-2 border-t border-slate-200 dark:border-slate-700">
           <a href="/" class="px-3 py-2 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-primary-500 transition-colors">Home</a>
@@ -130,32 +152,72 @@
   <main class="pt-24 pb-20">
     <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
 
-      <h1 class="text-4xl font-bold mb-2">Blog</h1>
-      <p class="text-slate-500 dark:text-slate-400 mb-12">Behind the scenes of building MailVault</p>
+      <a href="/blog.html" class="inline-flex items-center gap-1 text-sm text-primary-500 hover:text-primary-600 transition-colors mb-8">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        Back to Blog
+      </a>
 
-      <div class="space-y-6">
-
-        <!-- Gmail OAuth2 -->
-        <a href="/blog/gmail-oauth2.html" class="block group p-6 rounded-2xl bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 hover:border-primary-500 dark:hover:border-primary-500 transition-all hover:shadow-lg">
+      <article>
+        <header class="mb-8">
           <time datetime="2026-02-20" class="text-sm text-primary-500 font-medium">February 20, 2026</time>
-          <h2 class="text-xl font-bold mt-1 mb-2 group-hover:text-primary-500 transition-colors">Adding Gmail OAuth2: One Flow, Two Providers</h2>
-          <p class="text-slate-600 dark:text-slate-400 text-sm leading-relaxed">How we made MailVault's existing Microsoft OAuth2 PKCE flow provider-agnostic and added Google sign-in — no app passwords, no IMAP settings to find.</p>
-          <div class="flex items-center gap-2 mt-3 text-xs text-slate-400 dark:text-slate-500">
+          <h1 class="text-3xl sm:text-4xl font-bold mt-2 mb-3">Adding Gmail OAuth2: One Flow, Two Providers</h1>
+          <div class="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
             <span>4 min read</span>
           </div>
-        </a>
+        </header>
 
-        <!-- Sandbox Signing Saga -->
-        <a href="/blog/sandbox-signing-saga.html" class="block group p-6 rounded-2xl bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 hover:border-primary-500 dark:hover:border-primary-500 transition-all hover:shadow-lg">
-          <time datetime="2026-02-18" class="text-sm text-primary-500 font-medium">February 18, 2026</time>
-          <h2 class="text-xl font-bold mt-1 mb-2 group-hover:text-primary-500 transition-colors">The macOS Sandbox Signing Saga (or Why v1.4.0 Through v1.4.5 Exist)</h2>
-          <p class="text-slate-600 dark:text-slate-400 text-sm leading-relaxed">Six patch releases in a single day. macOS code signing, App Sandbox, and Bun-compiled sidecars don't mix well — here's the full story of how we fixed it.</p>
-          <div class="flex items-center gap-2 mt-3 text-xs text-slate-400 dark:text-slate-500">
-            <span>5 min read</span>
-          </div>
-        </a>
+        <div class="prose prose-slate dark:prose-invert max-w-none space-y-5 text-slate-700 dark:text-slate-300 leading-relaxed">
 
-      </div>
+          <p>
+            When we shipped Microsoft OAuth2 in v1.2.0, the goal was clear: let users sign in with their existing Microsoft account instead of generating an app password. It worked well for Outlook, Hotmail, and M365 accounts. The natural next step was Gmail &mdash; the most popular email provider in the world.
+          </p>
+
+          <h3 class="text-xl font-semibold text-slate-900 dark:text-slate-100 pt-2">Why OAuth2 Matters</h3>
+
+          <p>
+            Google has been tightening access to IMAP for years. If you have 2FA enabled (and you should), you need an <a href="https://support.google.com/accounts/answer/185833" class="text-primary-500 hover:text-primary-600 underline">App Password</a> to use third-party email clients. App passwords work, but they're obscure, easy to forget, and feel like a workaround. OAuth2 lets users click "Sign in with Google," authenticate in their browser, and come back to the app &mdash; no passwords copied, no settings pages searched.
+          </p>
+
+          <h3 class="text-xl font-semibold text-slate-900 dark:text-slate-100 pt-2">The Implementation</h3>
+
+          <p>
+            MailVault already had a working OAuth2 PKCE flow for Microsoft, written in Rust. The architecture has three parts: a local TCP callback server on <code>localhost:19876</code> that receives the redirect after browser login, a token exchange function that swaps the authorization code for access/refresh tokens, and XOAUTH2 SASL authentication for IMAP and SMTP.
+          </p>
+
+          <p>
+            Adding Google meant making all of this provider-agnostic. Instead of hardcoding Microsoft's endpoints, we refactored the Rust OAuth2 module to accept provider configuration at runtime &mdash; authorization URL, token URL, scopes, and client ID all come from the frontend when initiating the flow.
+          </p>
+
+          <p>
+            For the client ID, we followed the same approach as Microsoft: use a well-known public client ID. Thunderbird, the open-source email client by Mozilla, registers public OAuth2 clients with both Google and Microsoft. MailVault uses Thunderbird's Google client ID (<code>406964657835-aq8lmia8j95dhl1a2bvharmfk3t1hgqj.apps.googleusercontent.com</code>) with the <code>https://mail.google.com/</code> scope, which grants full IMAP and SMTP access.
+          </p>
+
+          <h3 class="text-xl font-semibold text-slate-900 dark:text-slate-100 pt-2">What Changed in the Code</h3>
+
+          <p>
+            The Rust side needed a new <code>oauth2_start</code> command that accepts provider-specific parameters (auth URL, token URL, scopes, client ID) instead of assuming Microsoft. The callback server and PKCE logic stayed the same &mdash; OAuth2 is OAuth2, regardless of provider.
+          </p>
+
+          <p>
+            On the frontend, the <code>AccountModal</code> component now shows a "Sign in with Google" button for Gmail accounts (alongside the existing "Use App Password instead" fallback). The button triggers the same OAuth2 flow, just with Google's endpoints and scopes instead of Microsoft's. After authentication, the access token is used with XOAUTH2 SASL for both IMAP (<code>imap.gmail.com</code>) and SMTP (<code>smtp.gmail.com</code>).
+          </p>
+
+          <p>
+            Token refresh works identically to Microsoft: when an access token expires (typically after one hour), MailVault automatically refreshes it using the stored refresh token. The user never has to re-authenticate unless they revoke access from their Google account settings.
+          </p>
+
+          <h3 class="text-xl font-semibold text-slate-900 dark:text-slate-100 pt-2">The Result</h3>
+
+          <p>
+            Gmail users can now click one button, sign in through Google's standard login page, and start using MailVault immediately. No app passwords, no IMAP settings to find, no "less secure apps" toggles. It works with 2FA, Google Workspace, and personal Gmail accounts.
+          </p>
+
+          <p>
+            The same OAuth2 infrastructure is now ready for any future provider that supports standard OAuth2 &mdash; the Rust module is fully provider-agnostic.
+          </p>
+
+        </div>
+      </article>
 
     </div>
   </main>
@@ -165,7 +227,7 @@
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex flex-col md:flex-row items-center justify-between gap-4">
         <div class="flex items-center gap-2">
-          <img src="icon-128.png" alt="MailVault logo" class="w-8 h-8 rounded-lg">
+          <img src="/icon-128.png" alt="MailVault logo" class="w-8 h-8 rounded-lg">
           <span class="font-bold text-lg">Mail<span class="text-primary-500">Vault</span></span>
         </div>
 
@@ -196,7 +258,6 @@
       moonIcon.classList.toggle('hidden', isDark);
     }
 
-    // Initialize theme
     if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
       document.documentElement.classList.add('dark');
     }
@@ -213,13 +274,11 @@
     const mobileMenu = document.getElementById('mobile-menu');
     const menuIconOpen = document.getElementById('menu-icon-open');
     const menuIconClose = document.getElementById('menu-icon-close');
-
     mobileMenuBtn.addEventListener('click', () => {
       mobileMenu.classList.toggle('hidden');
       menuIconOpen.classList.toggle('hidden');
       menuIconClose.classList.toggle('hidden');
     });
-
     document.querySelectorAll('#mobile-menu a').forEach(link => {
       link.addEventListener('click', () => {
         mobileMenu.classList.add('hidden');

--- a/website/blog/sandbox-signing-saga.html
+++ b/website/blog/sandbox-signing-saga.html
@@ -1,0 +1,338 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The macOS Sandbox Signing Saga - MailVault Blog</title>
+  <meta name="description" content="How macOS code signing and App Sandbox nearly broke MailVault, and the six patch releases it took to fix it.">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://mailvaultapp.com/blog/sandbox-signing-saga.html">
+  <meta name="theme-color" content="#6366f1">
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://mailvaultapp.com/blog/sandbox-signing-saga.html">
+  <meta property="og:title" content="The macOS Sandbox Signing Saga - MailVault Blog">
+  <meta property="og:description" content="How macOS code signing and App Sandbox nearly broke MailVault, and the six patch releases it took to fix it.">
+  <meta property="og:image" content="https://mailvaultapp.com/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:site_name" content="MailVault">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The macOS Sandbox Signing Saga - MailVault Blog">
+  <meta name="twitter:description" content="How macOS code signing and App Sandbox nearly broke MailVault, and the six patch releases it took to fix it.">
+  <meta name="twitter:image" content="https://mailvaultapp.com/og-image.png">
+  <meta name="twitter:site" content="@GraphicMeat">
+
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            primary: {
+              50: '#eef2ff', 100: '#e0e7ff', 200: '#c7d2fe', 300: '#a5b4fc',
+              400: '#818cf8', 500: '#6366f1', 600: '#4f46e5', 700: '#4338ca',
+              800: '#3730a3', 900: '#312e81',
+            }
+          }
+        }
+      }
+    }
+  </script>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+  <style>
+    body { font-family: 'Inter', system-ui, sans-serif; }
+    .gradient-text {
+      background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 50%, #a855f7 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .gradient-bg { background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%); }
+    .glass {
+      background: rgba(255, 255, 255, 0.05);
+      backdrop-filter: blur(10px);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+    }
+    .dark .glass {
+      background: rgba(0, 0, 0, 0.2);
+      border: 1px solid rgba(255, 255, 255, 0.05);
+    }
+    article pre {
+      background: #1e293b;
+      color: #e2e8f0;
+      padding: 1rem 1.25rem;
+      border-radius: 0.75rem;
+      overflow-x: auto;
+      font-size: 0.875rem;
+      line-height: 1.7;
+    }
+    .dark article pre {
+      background: #0f172a;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+    }
+    article code:not(pre code) {
+      background: rgba(99, 102, 241, 0.1);
+      color: #6366f1;
+      padding: 0.15rem 0.4rem;
+      border-radius: 0.25rem;
+      font-size: 0.875em;
+    }
+    .dark article code:not(pre code) {
+      background: rgba(99, 102, 241, 0.2);
+      color: #a5b4fc;
+    }
+  </style>
+</head>
+
+<body class="bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 transition-colors duration-300">
+
+  <!-- Navigation -->
+  <nav role="banner" class="fixed top-0 left-0 right-0 z-50 glass">
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex items-center justify-between h-16">
+        <a href="/" class="flex items-center gap-3">
+          <img src="/icon-128.png" alt="MailVault logo" class="w-8 h-8 rounded-lg">
+          <span class="font-bold text-xl">Mail<span class="text-primary-500">Vault</span></span>
+        </a>
+
+        <div class="hidden md:flex items-center gap-8">
+          <a href="/#features" class="text-slate-600 dark:text-slate-300 hover:text-primary-500 transition-colors">Features</a>
+          <a href="/#how-it-works" class="text-slate-600 dark:text-slate-300 hover:text-primary-500 transition-colors">How It Works</a>
+          <a href="/faq.html" class="text-slate-600 dark:text-slate-300 hover:text-primary-500 transition-colors">FAQ</a>
+          <a href="/changelog.html" class="text-slate-600 dark:text-slate-300 hover:text-primary-500 transition-colors">Changelog</a>
+          <a href="/blog.html" class="text-primary-500 font-medium">Blog</a>
+          <a href="/#contact" class="text-slate-600 dark:text-slate-300 hover:text-primary-500 transition-colors">Contact</a>
+        </div>
+
+        <div class="flex items-center gap-4">
+          <button id="theme-toggle" class="p-2 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors" title="Toggle theme">
+            <svg id="sun-icon" class="w-5 h-5 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+            <svg id="moon-icon" class="w-5 h-5 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+          </button>
+          <a href="https://github.com/GraphicMeat/mail-vault-app/releases/latest" target="_blank" class="hidden sm:inline-flex gradient-bg text-white px-4 py-2 rounded-lg font-medium hover:opacity-90 transition-opacity">
+            Download
+          </a>
+          <button id="mobile-menu-btn" class="md:hidden p-2 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path id="menu-icon-open" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
+              <path id="menu-icon-close" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <div id="mobile-menu" class="hidden md:hidden pb-4">
+        <div class="flex flex-col gap-2 pt-2 border-t border-slate-200 dark:border-slate-700">
+          <a href="/" class="px-3 py-2 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-primary-500 transition-colors">Home</a>
+          <a href="/#features" class="px-3 py-2 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-primary-500 transition-colors">Features</a>
+          <a href="/#how-it-works" class="px-3 py-2 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-primary-500 transition-colors">How It Works</a>
+          <a href="/faq.html" class="px-3 py-2 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-primary-500 transition-colors">FAQ</a>
+          <a href="/changelog.html" class="px-3 py-2 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-primary-500 transition-colors">Changelog</a>
+          <a href="/blog.html" class="px-3 py-2 rounded-lg text-primary-500 font-medium">Blog</a>
+          <a href="/#contact" class="px-3 py-2 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-primary-500 transition-colors">Contact</a>
+          <a href="https://github.com/GraphicMeat/mail-vault-app/releases/latest" target="_blank" class="sm:hidden mt-1 px-3 py-2 rounded-lg gradient-bg text-white font-medium text-center hover:opacity-90 transition-opacity">Download</a>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main class="pt-24 pb-20">
+    <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+
+      <a href="/blog.html" class="inline-flex items-center gap-1 text-sm text-primary-500 hover:text-primary-600 transition-colors mb-8">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        Back to Blog
+      </a>
+
+      <article>
+        <header class="mb-8">
+          <time datetime="2026-02-18" class="text-sm text-primary-500 font-medium">February 18, 2026</time>
+          <h1 class="text-3xl sm:text-4xl font-bold mt-2 mb-3">The macOS Sandbox Signing Saga (or Why v1.4.0 Through v1.4.5 Exist)</h1>
+          <div class="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+            <span>5 min read</span>
+          </div>
+        </header>
+
+        <div class="prose prose-slate dark:prose-invert max-w-none space-y-5 text-slate-700 dark:text-slate-300 leading-relaxed">
+
+          <p>
+            If you looked at our <a href="/changelog.html" class="text-primary-500 hover:text-primary-600 underline">changelog</a> today and noticed six patch releases in a single day, you might be wondering what happened. The short answer: macOS code signing and App Sandbox nearly broke us. Here's the full story.
+          </p>
+
+          <h3 class="text-xl font-semibold text-slate-900 dark:text-slate-100 pt-2">How MailVault Works Under the Hood</h3>
+
+          <p>
+            MailVault is a <a href="https://v2.tauri.app" class="text-primary-500 hover:text-primary-600 underline">Tauri v2</a> desktop app. The frontend is React running in a native webview, and the backend is a Node.js Express server compiled into a native binary using <a href="https://bun.sh" class="text-primary-500 hover:text-primary-600 underline">Bun</a>. This binary (called a "sidecar") runs alongside the main app and handles all IMAP/SMTP communication.
+          </p>
+
+          <p>
+            For macOS distribution, Apple requires apps to be signed with a Developer ID certificate and notarized. We also enable <strong>App Sandbox</strong> &mdash; Apple's security layer that restricts what the app can access on your system. It's required for the Mac App Store and is good practice for any desktop app.
+          </p>
+
+          <h3 class="text-xl font-semibold text-slate-900 dark:text-slate-100 pt-2">The Problem</h3>
+
+          <p>
+            After releasing v1.4.0, we discovered that the sidecar server wasn't starting in release builds. The app launched fine, but the backend was silently crashing with exit code 133 (SIGTRAP). Everything worked perfectly in development &mdash; only the signed, sandboxed release build was affected.
+          </p>
+
+          <p>
+            It took several iterations to peel back the layers:
+          </p>
+
+          <ul class="list-disc pl-6 space-y-2">
+            <li><strong>v1.4.0</strong> &mdash; Server bound to <code>0.0.0.0</code> but the frontend connected to <code>localhost</code>, causing IPv4/IPv6 mismatch. Fixed by binding explicitly to <code>127.0.0.1</code>.</li>
+            <li><strong>v1.4.1</strong> &mdash; The "Add Account" modal used a raw <code>fetch('/api/test-connection')</code> instead of the API helper. In Tauri release builds, the webview origin is <code>tauri://localhost</code>, not <code>http://localhost</code> &mdash; so relative URLs resolve to the wrong place.</li>
+            <li><strong>v1.4.2</strong> &mdash; Missing <code>com.apple.security.network.server</code> entitlement. The sandbox blocked the sidecar from listening on a port.</li>
+            <li><strong>v1.4.3</strong> &mdash; We had shell-based process cleanup (<code>lsof</code>, <code>kill</code>) that's blocked inside App Sandbox. Replaced with Tauri's <code>CommandChild</code> handle.</li>
+            <li><strong>v1.4.4</strong> &mdash; The real culprit: <strong>Bun-compiled binaries need JIT</strong> (Just-In-Time compilation). The JIT compiler allocates executable memory at runtime. While macOS has entitlements to allow this (<code>com.apple.security.cs.allow-jit</code>), Tauri signs all binaries in the app bundle with the <strong>same entitlements</strong> using <code>--deep</code>. The sidecar ended up with App Sandbox entitlements, which blocked JIT even with the allow-jit flag present.</li>
+            <li><strong>v1.4.5</strong> &mdash; Fixed the signing pipeline. The sidecar is now signed separately with its own entitlements (no App Sandbox, JIT allowed). The main app keeps App Sandbox. Signing order matters: sidecar first, then the main app bundle <em>without</em> <code>--deep</code> to preserve the sidecar's entitlements. Also caught that our CI pipeline was uploading Tauri's auto-generated unsigned DMG instead of our properly signed one.</li>
+          </ul>
+
+          <h3 class="text-xl font-semibold text-slate-900 dark:text-slate-100 pt-2">The Fix</h3>
+
+          <p>
+            The solution has two parts:
+          </p>
+
+          <ol class="list-decimal pl-6 space-y-2">
+            <li><strong>Separate entitlements</strong> &mdash; The sidecar gets <code>entitlements-sidecar.plist</code> (JIT + network, no sandbox). The main app gets <code>entitlements.plist</code> (sandbox + JIT + network).</li>
+            <li><strong>Correct signing order</strong> &mdash; Sign the sidecar first with its own entitlements, then sign the main <code>.app</code> bundle without <code>--deep</code>. Using <code>--deep</code> would recursively re-sign everything inside the bundle, overwriting the sidecar's entitlements.</li>
+          </ol>
+
+          <h3 class="text-xl font-semibold text-slate-900 dark:text-slate-100 pt-2">How to Verify the Signing Yourself</h3>
+
+          <p>
+            If you want to verify that MailVault is properly signed and notarized on your machine, open Terminal and run these commands:
+          </p>
+
+          <p><strong>1. Verify the app signature:</strong></p>
+
+          <pre>codesign --verify --verbose /Applications/MailVault.app</pre>
+
+          <p>You should see:</p>
+          <pre>/Applications/MailVault.app: valid on disk
+/Applications/MailVault.app: satisfies its Designated Requirement</pre>
+
+          <p><strong>2. Check the main app's entitlements:</strong></p>
+
+          <pre>codesign -d --entitlements - /Applications/MailVault.app</pre>
+
+          <p>Look for <code>com.apple.security.app-sandbox</code> set to <code>true</code> &mdash; this confirms the app runs in a sandbox.</p>
+
+          <p><strong>3. Check the sidecar's entitlements:</strong></p>
+
+          <pre>codesign -d --entitlements - /Applications/MailVault.app/Contents/MacOS/mailvault-server</pre>
+
+          <p>The sidecar should have <code>com.apple.security.cs.allow-jit</code> but should <strong>not</strong> have <code>com.apple.security.app-sandbox</code>.</p>
+
+          <p><strong>4. Verify notarization:</strong></p>
+
+          <pre>spctl --assess --type execute -v /Applications/MailVault.app</pre>
+
+          <p>You should see:</p>
+          <pre>/Applications/MailVault.app: accepted
+source=Notarized Developer ID</pre>
+
+          <p><strong>5. Check the DMG notarization (before installing):</strong></p>
+
+          <pre>spctl --assess --type open --context context:primary-signature -v ~/Downloads/MailVault-v1.4.5.dmg</pre>
+
+          <h3 class="text-xl font-semibold text-slate-900 dark:text-slate-100 pt-2">Lessons Learned</h3>
+
+          <ul class="list-disc pl-6 space-y-2">
+            <li><strong>Test release builds early.</strong> Development builds skip code signing and sandboxing entirely. The gap between "works in dev" and "works in release" can be enormous.</li>
+            <li><strong>Sidecars need special treatment.</strong> If you're bundling a Bun/Node/Deno compiled binary inside a Tauri app, it needs its own entitlements. Tauri doesn't support per-binary entitlements natively &mdash; you have to re-sign after the build.</li>
+            <li><strong><code>--deep</code> is dangerous.</strong> It's convenient but it overwrites all nested signatures with the same entitlements. If different binaries need different entitlements, sign them individually.</li>
+            <li><strong>One build script for local and CI.</strong> Having separate signing logic for local builds and CI caused the CI to upload the wrong (unsigned) DMG. Now both use the same script.</li>
+          </ul>
+
+          <p>
+            If you were affected by the broken releases, we apologize for the inconvenience. v1.4.5 is the stable, properly signed release. Your emails were never at risk &mdash; the issue was purely about the app binary not launching its backend server.
+          </p>
+        </div>
+      </article>
+
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer class="border-t border-slate-200 dark:border-slate-800 py-8">
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex flex-col md:flex-row items-center justify-between gap-4">
+        <div class="flex items-center gap-2">
+          <img src="/icon-128.png" alt="MailVault logo" class="w-8 h-8 rounded-lg">
+          <span class="font-bold text-lg">Mail<span class="text-primary-500">Vault</span></span>
+        </div>
+
+        <div class="flex items-center gap-6 text-sm text-slate-600 dark:text-slate-400">
+          <a href="/privacy.html" class="hover:text-primary-500 transition-colors">Privacy Policy</a>
+          <a href="/faq.html" class="hover:text-primary-500 transition-colors">FAQ</a>
+          <a href="/changelog.html" class="hover:text-primary-500 transition-colors">Changelog</a>
+          <a href="/blog.html" class="hover:text-primary-500 transition-colors">Blog</a>
+          <a href="/terms.html" class="hover:text-primary-500 transition-colors">Terms of Service</a>
+        </div>
+
+        <p class="text-sm text-slate-500 dark:text-slate-400">
+          &copy; 2026 MailVault. All rights reserved.
+        </p>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // Theme toggle
+    const themeToggle = document.getElementById('theme-toggle');
+    const sunIcon = document.getElementById('sun-icon');
+    const moonIcon = document.getElementById('moon-icon');
+
+    function updateThemeIcons() {
+      const isDark = document.documentElement.classList.contains('dark');
+      sunIcon.classList.toggle('hidden', !isDark);
+      moonIcon.classList.toggle('hidden', isDark);
+    }
+
+    if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      document.documentElement.classList.add('dark');
+    }
+    updateThemeIcons();
+
+    themeToggle.addEventListener('click', () => {
+      document.documentElement.classList.toggle('dark');
+      localStorage.theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+      updateThemeIcons();
+    });
+
+    // Mobile Menu
+    const mobileMenuBtn = document.getElementById('mobile-menu-btn');
+    const mobileMenu = document.getElementById('mobile-menu');
+    const menuIconOpen = document.getElementById('menu-icon-open');
+    const menuIconClose = document.getElementById('menu-icon-close');
+    mobileMenuBtn.addEventListener('click', () => {
+      mobileMenu.classList.toggle('hidden');
+      menuIconOpen.classList.toggle('hidden');
+      menuIconClose.classList.toggle('hidden');
+    });
+    document.querySelectorAll('#mobile-menu a').forEach(link => {
+      link.addEventListener('click', () => {
+        mobileMenu.classList.add('hidden');
+        menuIconOpen.classList.remove('hidden');
+        menuIconClose.classList.add('hidden');
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/website/changelog.html
+++ b/website/changelog.html
@@ -78,54 +78,18 @@
   <nav role="banner" class="fixed top-0 left-0 right-0 z-50 glass">
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex items-center justify-between h-16">
-        <a href="/" class="flex items-center gap-3">
+        <a href="/" class="flex items-center gap-2">
           <img src="icon-128.png" alt="MailVault logo" class="w-8 h-8 rounded-lg">
           <span class="font-bold text-xl">Mail<span class="text-primary-500">Vault</span></span>
         </a>
-
-        <div class="hidden md:flex items-center gap-8">
-          <a href="/#features" class="text-slate-600 dark:text-slate-300 hover:text-primary-500 transition-colors">Features</a>
-          <a href="/#how-it-works" class="text-slate-600 dark:text-slate-300 hover:text-primary-500 transition-colors">How It Works</a>
-          <a href="/faq.html" class="text-slate-600 dark:text-slate-300 hover:text-primary-500 transition-colors">FAQ</a>
-          <a href="/changelog.html" class="text-primary-500 font-medium">Changelog</a>
-          <a href="/blog.html" class="text-slate-600 dark:text-slate-300 hover:text-primary-500 transition-colors">Blog</a>
-          <a href="/#contact" class="text-slate-600 dark:text-slate-300 hover:text-primary-500 transition-colors">Contact</a>
-        </div>
-
-        <div class="flex items-center gap-4">
-          <button id="theme-toggle" class="p-2 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors">
-            <svg class="w-5 h-5 hidden dark:block" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-              <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"/>
-            </svg>
-            <svg class="w-5 h-5 block dark:hidden" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-              <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
-            </svg>
-          </button>
-          <a href="https://github.com/GraphicMeat/mail-vault-app/releases/latest" target="_blank" class="hidden sm:inline-flex gradient-bg text-white px-4 py-2 rounded-lg font-medium hover:opacity-90 transition-opacity">
-            Download
-          </a>
-          <!-- Mobile menu button -->
-          <button id="mobile-menu-btn" class="md:hidden p-2 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors">
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path id="menu-icon-open" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
-              <path id="menu-icon-close" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
-            </svg>
-          </button>
-        </div>
-      </div>
-
-      <!-- Mobile menu -->
-      <div id="mobile-menu" class="hidden md:hidden pb-4">
-        <div class="flex flex-col gap-2 pt-2 border-t border-slate-200 dark:border-slate-700">
-          <a href="/" class="px-3 py-2 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-primary-500 transition-colors">Home</a>
-          <a href="/#features" class="px-3 py-2 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-primary-500 transition-colors">Features</a>
-          <a href="/#how-it-works" class="px-3 py-2 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-primary-500 transition-colors">How It Works</a>
-          <a href="/faq.html" class="px-3 py-2 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-primary-500 transition-colors">FAQ</a>
-          <a href="/changelog.html" class="px-3 py-2 rounded-lg text-primary-500 font-medium">Changelog</a>
-          <a href="/blog.html" class="px-3 py-2 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-primary-500 transition-colors">Blog</a>
-          <a href="/#contact" class="px-3 py-2 rounded-lg text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-primary-500 transition-colors">Contact</a>
-          <a href="https://github.com/GraphicMeat/mail-vault-app/releases/latest" target="_blank" class="sm:hidden mt-1 px-3 py-2 rounded-lg gradient-bg text-white font-medium text-center hover:opacity-90 transition-opacity">Download</a>
-        </div>
+        <button id="theme-toggle" class="p-2 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors">
+          <svg class="w-5 h-5 hidden dark:block" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"/>
+          </svg>
+          <svg class="w-5 h-5 block dark:hidden" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
+          </svg>
+        </button>
       </div>
     </div>
   </nav>
@@ -138,9 +102,81 @@
 
       <article class="mb-16">
         <div class="flex items-center gap-3 mb-6">
+          <span class="inline-flex items-center px-3 py-1 rounded-full gradient-bg text-white text-sm font-semibold">v1.7.0</span>
+          <span class="text-slate-500 dark:text-slate-400 text-sm">February 21, 2026</span>
+          <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400 text-xs font-medium">Latest</span>
+        </div>
+
+        <div class="mb-8">
+          <h3 class="flex items-center gap-2 text-lg font-semibold mb-4">
+            <span class="w-7 h-7 rounded-lg bg-green-100 dark:bg-green-900/30 flex items-center justify-center flex-shrink-0">
+              <svg class="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/></svg>
+            </span>
+            Added
+          </h3>
+          <ul class="space-y-3 text-slate-600 dark:text-slate-400">
+            <li class="flex items-start gap-3">
+              <span class="w-1.5 h-1.5 rounded-full bg-green-500 flex-shrink-0 mt-2"></span>
+              <span><strong>Email threading (Gmail-style)</strong> — emails are now grouped into threads using RFC 2822 <code class="text-sm px-1 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 font-mono inline">In-Reply-To</code> and <code class="text-sm px-1 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 font-mono inline">References</code> headers, with normalized subject as fallback; the regular email list shows collapsed thread rows with participant names, message count badges, and latest date; the chat view uses the same threading algorithm for its topic grouping; Rust IMAP layer now fetches <code class="text-sm px-1 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 font-mono inline">In-Reply-To</code> from ENVELOPE and <code class="text-sm px-1 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 font-mono inline">References</code> via <code class="text-sm px-1 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 font-mono inline">BODY.PEEK[HEADER.FIELDS (References)]</code></span>
+            </li>
+            <li class="flex items-start gap-3">
+              <span class="w-1.5 h-1.5 rounded-full bg-green-500 flex-shrink-0 mt-2"></span>
+              <span><strong>Thread conversation view</strong> — clicking a thread in the email list now shows all emails in the thread as a stacked conversation in the viewer; emails are sorted chronologically with the latest expanded by default; each email has its own reply/reply-all/forward buttons and attachment section; email bodies load progressively using the same concurrent loader as the chat view</span>
+            </li>
+            <li class="flex items-start gap-3">
+              <span class="w-1.5 h-1.5 rounded-full bg-green-500 flex-shrink-0 mt-2"></span>
+              <span><strong>Chat view: sent message merge</strong> — chat conversations now display both received (INBOX) and sent messages together; Sent folder headers are synced via the background pipeline and merged with INBOX emails, with deduplication by Message-ID to avoid duplicates; body loading handles per-mailbox IMAP fetches transparently</span>
+            </li>
+            <li class="flex items-start gap-3">
+              <span class="w-1.5 h-1.5 rounded-full bg-green-500 flex-shrink-0 mt-2"></span>
+              <span><strong>Clear cache button</strong> — Settings > General > Local Email Caching now has a "Clear Cache" button that removes all cached .eml files and headers, preserves archived emails, and restarts the sync pipeline</span>
+            </li>
+            <li class="flex items-start gap-3">
+              <span class="w-1.5 h-1.5 rounded-full bg-green-500 flex-shrink-0 mt-2"></span>
+              <span><strong>Hide/unhide accounts</strong> — accounts can be hidden from Settings > Accounts; hidden accounts disappear from the sidebar and stop all syncing (background pipelines, scheduled refresh); unhiding immediately resumes sync; if the active account is hidden, the app switches to the next visible account</span>
+            </li>
+          </ul>
+        </div>
+
+        <div class="mb-8">
+          <h3 class="flex items-center gap-2 text-lg font-semibold mb-4">
+            <span class="w-7 h-7 rounded-lg bg-slate-100 dark:bg-slate-900/30 flex items-center justify-center flex-shrink-0">
+              <svg class="w-4 h-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4"/></svg>
+            </span>
+            Removed
+          </h3>
+          <ul class="space-y-3 text-slate-600 dark:text-slate-400">
+            <li class="flex items-start gap-3">
+              <span class="w-1.5 h-1.5 rounded-full bg-slate-500 flex-shrink-0 mt-2"></span>
+              <span><strong>App Password fallback for OAuth2 providers</strong> — Gmail and Microsoft accounts no longer show the "Use App Password instead" toggle; OAuth2 is the only authentication method for these providers as app passwords are less secure</span>
+            </li>
+          </ul>
+        </div>
+
+        <div class="mb-8">
+          <h3 class="flex items-center gap-2 text-lg font-semibold mb-4">
+            <span class="w-7 h-7 rounded-lg bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center flex-shrink-0">
+              <svg class="w-4 h-4 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"/></svg>
+            </span>
+            Fixed
+          </h3>
+          <ul class="space-y-3 text-slate-600 dark:text-slate-400">
+            <li class="flex items-start gap-3">
+              <span class="w-1.5 h-1.5 rounded-full bg-amber-500 flex-shrink-0 mt-2"></span>
+              <span><strong>Thread row actions</strong> — threaded email rows in the list view now show archive and more-menu buttons on hover (matching single-email rows); archive button archives all emails in the thread; more menu offers "Delete thread from server" with confirmation</span>
+            </li>
+            <li class="flex items-start gap-3">
+              <span class="w-1.5 h-1.5 rounded-full bg-amber-500 flex-shrink-0 mt-2"></span>
+              <span><strong>Chat view "Content cannot be displayed"</strong> — chat bubbles showed "Content cannot be displayed" for all messages because the chat view only received header-only emails (no body content); added progressive body loading via <code class="text-sm px-1 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 font-mono inline">useChatBodyLoader</code> hook that fetches email bodies concurrently (3 at a time) from cache → Maildir → IMAP, with per-bubble loading spinners and targeted re-renders</span>
+            </li>
+          </ul>
+        </div>
+
+      </article>
+      <article class="mb-16">
+        <div class="flex items-center gap-3 mb-6">
           <span class="inline-flex items-center px-3 py-1 rounded-full gradient-bg text-white text-sm font-semibold">v1.6.0</span>
           <span class="text-slate-500 dark:text-slate-400 text-sm">February 20, 2026</span>
-          <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400 text-xs font-medium">Latest</span>
         </div>
 
         <div class="mb-8">
@@ -1230,24 +1266,6 @@
     themeToggle.addEventListener('click', () => {
       html.classList.toggle('dark');
       localStorage.theme = html.classList.contains('dark') ? 'dark' : 'light';
-    });
-
-    // Mobile Menu
-    const mobileMenuBtn = document.getElementById('mobile-menu-btn');
-    const mobileMenu = document.getElementById('mobile-menu');
-    const menuIconOpen = document.getElementById('menu-icon-open');
-    const menuIconClose = document.getElementById('menu-icon-close');
-    mobileMenuBtn.addEventListener('click', () => {
-      mobileMenu.classList.toggle('hidden');
-      menuIconOpen.classList.toggle('hidden');
-      menuIconClose.classList.toggle('hidden');
-    });
-    document.querySelectorAll('#mobile-menu a').forEach(link => {
-      link.addEventListener('click', () => {
-        mobileMenu.classList.add('hidden');
-        menuIconOpen.classList.remove('hidden');
-        menuIconClose.classList.add('hidden');
-      });
     });
   </script>
 </body>

--- a/website/faq.html
+++ b/website/faq.html
@@ -24,6 +24,7 @@
   <meta name="twitter:title" content="FAQ - MailVault | Frequently Asked Questions">
   <meta name="twitter:description" content="Frequently asked questions about MailVault. Learn how MailVault backs up your IMAP emails locally on macOS, supported providers, security, and more.">
   <meta name="twitter:image" content="https://mailvaultapp.com/og-image.png">
+  <meta name="twitter:site" content="@GraphicMeat">
 
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
@@ -174,7 +175,7 @@
         "name": "Does MailVault work with Gmail and Outlook?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Yes. MailVault works with Gmail, Outlook, and any other email service that supports IMAP. For Gmail, you may need to enable IMAP access and use an App Password if you have two-factor authentication enabled. Microsoft 365 Business and Enterprise accounts can sign in directly with your Microsoft account using OAuth2. Personal Outlook.com accounts are currently affected by a known Microsoft server issue."
+          "text": "Yes. MailVault works with Gmail, Outlook, and any other email service that supports IMAP. For Gmail, sign in directly with your Google account using OAuth2 — no manual IMAP settings needed. Microsoft 365 Business and Enterprise accounts can sign in directly with your Microsoft account using OAuth2. Personal Outlook.com accounts are currently affected by a known Microsoft server issue."
         }
       },
       {
@@ -182,7 +183,7 @@
         "name": "Why can't I connect my Outlook.com account?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "There is a known Microsoft server-side issue affecting personal Outlook.com, Hotmail, and Live.com accounts since late 2024. After signing in with your Microsoft account, the IMAP connection fails with 'User is authenticated but not connected.' Microsoft has deprecated basic authentication (including app passwords) for personal accounts, making OAuth2 the only method, but their IMAP service has a regression. Microsoft 365 Business/Enterprise accounts are not affected. MailVault's OAuth2 implementation is ready and will work once Microsoft resolves the issue."
+          "text": "There is a known Microsoft server-side issue affecting personal Outlook.com, Hotmail, and Live.com accounts since late 2024. After signing in with your Microsoft account, the IMAP connection fails with 'User is authenticated but not connected.' Microsoft's IMAP service has a regression that prevents OAuth2-authenticated sessions from connecting. Microsoft 365 Business/Enterprise accounts are not affected. MailVault's OAuth2 implementation is ready and will work once Microsoft resolves the issue."
         }
       },
       {
@@ -461,7 +462,7 @@
           </button>
           <div class="faq-answer">
             <p class="text-slate-600 dark:text-slate-400 leading-relaxed px-6 pb-5">
-              Yes. MailVault works with Gmail, Outlook, and any other email service that supports IMAP. For Gmail, you may need to enable IMAP access and use an App Password if you have two-factor authentication enabled. Microsoft 365 Business and Enterprise accounts can sign in directly with your Microsoft account using OAuth2 — no app password needed, and it works seamlessly with two-factor authentication. Personal Outlook.com accounts are currently affected by a <a href="#microsoft-outlook-oauth2" class="text-primary-500 hover:underline">known Microsoft server issue</a>.
+              Yes. MailVault works with Gmail, Outlook, and any other email service that supports IMAP. For Gmail, sign in directly with your Google account using OAuth2 — no manual IMAP settings needed. Microsoft 365 Business and Enterprise accounts can sign in directly with your Microsoft account using OAuth2, and it works seamlessly with two-factor authentication. Personal Outlook.com accounts are currently affected by a <a href="#microsoft-outlook-oauth2" class="text-primary-500 hover:underline">known Microsoft server issue</a>.
             </p>
           </div>
         </div>
@@ -477,7 +478,7 @@
           <div class="faq-answer">
             <div class="text-slate-600 dark:text-slate-400 leading-relaxed px-6 pb-5">
               <p class="mb-4">There is a <strong>known Microsoft server-side issue</strong> affecting personal Outlook.com, Hotmail, and Live.com accounts since late 2024. After signing in with your Microsoft account, the IMAP connection fails with "User is authenticated but not connected." This affects all third-party email clients that use IMAP with OAuth2 — not just MailVault.</p>
-              <p class="mb-4">Microsoft has deprecated basic authentication (including app passwords) for personal accounts, making OAuth2 the only authentication method. Unfortunately, their IMAP service has a regression that prevents OAuth2-authenticated sessions from connecting to the mailbox.</p>
+              <p class="mb-4">Microsoft requires OAuth2 for personal accounts. Unfortunately, their IMAP service has a regression that prevents OAuth2-authenticated sessions from connecting to the mailbox.</p>
               <p class="mb-2 font-medium text-slate-700 dark:text-slate-300">What you can do:</p>
               <ul class="list-disc list-inside space-y-2 mb-4">
                 <li><strong>Microsoft 365 Business/Enterprise accounts</strong> are not affected — OAuth2 works normally for organizational accounts</li>

--- a/website/index.html
+++ b/website/index.html
@@ -25,6 +25,7 @@
   <meta name="twitter:title" content="MailVault — Free Local Email Backup for Mac | Store Emails Offline">
   <meta name="twitter:description" content="Back up your IMAP emails locally on macOS. MailVault stores emails offline in a local archive — keep them forever, even after server deletion. Free and open source.">
   <meta name="twitter:image" content="https://mailvaultapp.com/og-image.png">
+  <meta name="twitter:site" content="@GraphicMeat">
 
   <!-- Favicon -->
   <link rel="icon" type="image/x-icon" href="favicon.ico">
@@ -105,6 +106,9 @@
     "description": "Back up your IMAP emails locally on macOS. MailVault stores emails offline in a local archive — keep them forever, even after server deletion. Free and open source.",
     "operatingSystem": "macOS",
     "applicationCategory": "BusinessApplication",
+    "applicationSubCategory": "EmailApplication",
+    "softwareVersion": "1.6.0",
+    "datePublished": "2026-02-20",
     "offers": {
       "@type": "Offer",
       "price": "0",
@@ -112,14 +116,21 @@
     },
     "downloadUrl": "https://github.com/GraphicMeat/mail-vault-app/releases/latest",
     "featureList": [
-      "Local email storage",
-      "Privacy-first design",
-      "IMAP support",
-      "Gmail OAuth2",
-      "Microsoft 365 OAuth2",
-      "Offline access",
-      "Full-text search",
-      "Email backup"
+      "Local email storage in Maildir format",
+      "Privacy-first design — no cloud, no tracking",
+      "IMAP support for any email provider",
+      "Gmail OAuth2 sign-in",
+      "Microsoft 365 OAuth2 sign-in",
+      "Offline email access",
+      "Full-text search with filters",
+      "ZIP backup export and import",
+      "Email threading (Gmail-style conversations)",
+      "Chat conversation view",
+      "Bulk email archiving",
+      "Multi-account support",
+      "Dark and light themes",
+      "Native macOS app (Tauri, not Electron)",
+      "Auto-updater"
     ],
     "screenshot": "https://mailvaultapp.com/og-image.png",
     "author": {
@@ -584,7 +595,7 @@
           <h3 class="text-xl font-semibold mb-3">Email Management</h3>
           <ul class="space-y-2 text-slate-600 dark:text-slate-400">
             <li class="flex items-start gap-2"><svg class="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>Compose, reply, reply all, and forward</li>
-            <li class="flex items-start gap-2"><svg class="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>Gmail &amp; Microsoft 365 OAuth2 sign-in (no app password needed)</li>
+            <li class="flex items-start gap-2"><svg class="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>Gmail &amp; Microsoft 365 OAuth2 sign-in</li>
             <li class="flex items-start gap-2"><svg class="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>Advanced search (sender, date, attachments, folder)</li>
             <li class="flex items-start gap-2"><svg class="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>Bulk operations (select all, batch archive/delete)</li>
           </ul>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -24,6 +24,7 @@
   <meta name="twitter:title" content="Privacy Policy - MailVault">
   <meta name="twitter:description" content="MailVault privacy policy. Learn how we handle your data with our privacy-first email client.">
   <meta name="twitter:image" content="https://mailvaultapp.com/og-image.png">
+  <meta name="twitter:site" content="@GraphicMeat">
 
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">

--- a/website/terms.html
+++ b/website/terms.html
@@ -24,6 +24,7 @@
   <meta name="twitter:title" content="Terms of Service - MailVault">
   <meta name="twitter:description" content="MailVault terms of service. Read the terms and conditions for using MailVault.">
   <meta name="twitter:image" content="https://mailvaultapp.com/og-image.png">
+  <meta name="twitter:site" content="@GraphicMeat">
 
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">


### PR DESCRIPTION
## Summary
- **Email threading (Gmail-style)** — groups emails using RFC 2822 `In-Reply-To`/`References` headers with subject fallback
- **Thread conversation view** — stacked email viewer with per-email reply/forward and progressive body loading
- **Chat view: sent message merge** — sent and received messages displayed together in chat conversations
- **Clear cache button** — Settings > General, removes cached .eml files and headers
- **Hide/unhide accounts** — hide accounts from sidebar/syncing via Settings > Accounts
- **Remove app password fallback** — Gmail and Microsoft OAuth2 providers no longer offer "Use App Password instead" toggle
- Website SEO improvements (structured data, meta tags) and FAQ updates

## Test plan
- [ ] Verify email threading groups conversations correctly
- [ ] Test thread conversation view shows all emails with reply buttons
- [ ] Confirm chat view shows both sent and received messages
- [ ] Test clear cache button removes cache and restarts pipeline
- [ ] Test hide/unhide account workflow
- [ ] Verify Gmail and Microsoft sign-in flows work without app password option
- [ ] Run release pipeline and verify build artifacts