### PR TITLE
fix(e2e): make CI headless e2e job green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,8 +183,13 @@ jobs:
         run: |
           echo "=== e2e-home tree ==="
           find "$RUNNER_TEMP/e2e-home" -maxdepth 5 | head -80
-          find "$RUNNER_TEMP/e2e-home" -name "*.log" -type f | while read -r f; do
-            echo "=== $f ==="; tail -n 200 "$f"
+          # Dated rotation: mailvault.log.2026-08-03 — match *.log* not *.log
+          find "$RUNNER_TEMP/e2e-home" -name "*.log*" -type f | while read -r f; do
+            echo "=== $f ==="; tail -n 300 "$f"
+          done
+          for f in accounts.json frontend-settings.json; do
+            p="$RUNNER_TEMP/e2e-home/.local/share/com.mailvault.app/$f"
+            [ -f "$p" ] && { echo "=== $f ==="; cat "$p"; } || true
           done
       - name: Upload e2e screenshots
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,9 +168,28 @@ jobs:
         env:
           TAURI_APP_BINARY: ${{ github.workspace }}/target/debug/mailvault
           CI: "true"
+          # Fixed app HOME so the log-dump step below can find app/daemon logs.
+          E2E_DATA_DIR: ${{ runner.temp }}/e2e-home
           # GH runners have no GPU/render node; WebKitGTK's default DMABUF
           # renderer misbehaves under Xvfb (Tauri's documented CI workaround).
           WEBKIT_DISABLE_DMABUF_RENDERER: "1"
           # No a11y bus in CI — skip the AT-SPI bridge instead of probing for it.
           NO_AT_BRIDGE: "1"
-        run: dbus-run-session -- xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" npx wdio run wdio.conf.js --suite ui-headless
+        run: |
+          mkdir -p "$E2E_DATA_DIR"
+          dbus-run-session -- xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" npx wdio run wdio.conf.js --suite ui-headless
+      - name: Dump app/daemon logs
+        if: always()
+        run: |
+          echo "=== e2e-home tree ==="
+          find "$RUNNER_TEMP/e2e-home" -maxdepth 5 | head -80
+          find "$RUNNER_TEMP/e2e-home" -name "*.log" -type f | while read -r f; do
+            echo "=== $f ==="; tail -n 200 "$f"
+          done
+      - name: Upload e2e screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-diagnostics
+          path: ${{ runner.temp }}/e2e-home/*.png
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
             libwebkit2gtk-4.1-dev libgtk-3-dev \
             libayatana-appindicator3-dev librsvg2-dev \
             libssl-dev libglib2.0-dev libdbus-1-dev \
-            libsecret-1-dev patchelf xvfb dbus xdotool
+            libsecret-1-dev patchelf xvfb dbus
       - run: npm ci
       - name: Build Vite frontend
         run: npx vite build
@@ -130,48 +130,15 @@ jobs:
         run: cargo install tauri-webdriver-automation --locked --force
       - name: Create empty .env.test for UI-only suite
         run: touch .env.test
-      # TEMPORARY diagnostics: launch the app bare under xvfb and log when (if
-      # ever) its window maps, with and without the WebKit DMABUF renderer.
-      # Remove once the e2e job is stably green.
-      - name: Probe app startup under xvfb
-        env:
-          TAURI_WEBVIEW_AUTOMATION: "true"
-        run: |
-          echo "DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS:-unset}"
-          ls -la /dev/dri 2>/dev/null || echo "no /dev/dri"
-          probe() {
-            local label="$1"
-            export HOME="$(mktemp -d)"
-            echo "=== probe: $label (HOME=$HOME, start $(date +%T.%3N)) ==="
-            xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" bash -c '
-              timeout 90 "$GITHUB_WORKSPACE/target/debug/mailvault" 2>&1 \
-                | while IFS= read -r line; do printf "app %s: %s\n" "$(date +%T.%3N)" "$line"; done &
-              found=""
-              for i in $(seq 1 45); do
-                sleep 2
-                win=$(xdotool search --name MailVault 2>/dev/null | head -1)
-                if [ -n "$win" ]; then
-                  echo "window mapped at +$((i*2))s (id $win, $(date +%T.%3N))"
-                  found=1
-                  break
-                fi
-              done
-              [ -n "$found" ] || echo "window NEVER mapped within 90s"
-              pkill -x mailvault || true
-              wait
-            '
-          }
-          probe "default env"
-          export WEBKIT_DISABLE_DMABUF_RENDERER=1
-          probe "WEBKIT_DISABLE_DMABUF_RENDERER=1"
       - name: Run E2E tests (ui-headless suite)
         env:
           TAURI_APP_BINARY: ${{ github.workspace }}/target/debug/mailvault
           CI: "true"
           # Fixed app HOME so the log-dump step below can find app/daemon logs.
           E2E_DATA_DIR: ${{ runner.temp }}/e2e-home
-          # GH runners have no GPU/render node; WebKitGTK's default DMABUF
-          # renderer misbehaves under Xvfb (Tauri's documented CI workaround).
+          # Defensive: Tauri's documented CI setting for GPU-less runners.
+          # Probing showed the webview renders fine either way on today's
+          # runner image, but the software path is the stable one to pin.
           WEBKIT_DISABLE_DMABUF_RENDERER: "1"
           # No a11y bus in CI — skip the AT-SPI bridge instead of probing for it.
           NO_AT_BRIDGE: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
             libwebkit2gtk-4.1-dev libgtk-3-dev \
             libayatana-appindicator3-dev librsvg2-dev \
             libssl-dev libglib2.0-dev libdbus-1-dev \
-            libsecret-1-dev patchelf xvfb
+            libsecret-1-dev patchelf xvfb dbus xdotool
       - run: npm ci
       - name: Build Vite frontend
         run: npx vite build
@@ -130,8 +130,47 @@ jobs:
         run: cargo install tauri-webdriver-automation --locked --force
       - name: Create empty .env.test for UI-only suite
         run: touch .env.test
+      # TEMPORARY diagnostics: launch the app bare under xvfb and log when (if
+      # ever) its window maps, with and without the WebKit DMABUF renderer.
+      # Remove once the e2e job is stably green.
+      - name: Probe app startup under xvfb
+        env:
+          TAURI_WEBVIEW_AUTOMATION: "true"
+        run: |
+          echo "DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS:-unset}"
+          ls -la /dev/dri 2>/dev/null || echo "no /dev/dri"
+          probe() {
+            local label="$1"
+            export HOME="$(mktemp -d)"
+            echo "=== probe: $label (HOME=$HOME, start $(date +%T.%3N)) ==="
+            xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" bash -c '
+              timeout 90 "$GITHUB_WORKSPACE/target/debug/mailvault" 2>&1 \
+                | while IFS= read -r line; do printf "app %s: %s\n" "$(date +%T.%3N)" "$line"; done &
+              found=""
+              for i in $(seq 1 45); do
+                sleep 2
+                win=$(xdotool search --name MailVault 2>/dev/null | head -1)
+                if [ -n "$win" ]; then
+                  echo "window mapped at +$((i*2))s (id $win, $(date +%T.%3N))"
+                  found=1
+                  break
+                fi
+              done
+              [ -n "$found" ] || echo "window NEVER mapped within 90s"
+              pkill -x mailvault || true
+              wait
+            '
+          }
+          probe "default env"
+          export WEBKIT_DISABLE_DMABUF_RENDERER=1
+          probe "WEBKIT_DISABLE_DMABUF_RENDERER=1"
       - name: Run E2E tests (ui-headless suite)
         env:
           TAURI_APP_BINARY: ${{ github.workspace }}/target/debug/mailvault
           CI: "true"
-        run: xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" npx wdio run wdio.conf.js --suite ui-headless
+          # GH runners have no GPU/render node; WebKitGTK's default DMABUF
+          # renderer misbehaves under Xvfb (Tauri's documented CI workaround).
+          WEBKIT_DISABLE_DMABUF_RENDERER: "1"
+          # No a11y bus in CI — skip the AT-SPI bridge instead of probing for it.
+          NO_AT_BRIDGE: "1"
+        run: dbus-run-session -- xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" npx wdio run wdio.conf.js --suite ui-headless

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **The app no longer crashes at launch on Linux systems without a configured locale.** On a system where the language environment is unset (LANG empty, common on minimal installs and servers), the browser engine reports the raw "C" locale, and every date formatter rejected it — taking the whole window down to a "Something went wrong" screen before anything loaded. Date formatting now falls back to the system default when the reported locale isn't usable.
+
 ## [2.8.0] - 2026-07-26
 
 ### Fixed

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4281,6 +4281,12 @@ fn main() {
         eprintln!("PANIC at {}: {}", location, payload);
     }));
 
+    // Under WebDriver automation (tauri-wd sets this), single-instance protection is an
+    // anti-feature: each spec launches a fresh app instance, and a leftover instance from a
+    // failed session would make every subsequent launch exit(0) immediately — the harness
+    // then reports "App did not report plugin port in time" for the rest of the suite.
+    let automation = std::env::var_os("TAURI_WEBVIEW_AUTOMATION").is_some();
+
     // Linux fallback: flock-based lock to prevent multiple instances.
     // The tauri-plugin-single-instance uses D-Bus which may not work in all Linux environments
     // (AppImage, Snap, restricted D-Bus sessions). flock is kernel-managed: automatically
@@ -4289,7 +4295,7 @@ fn main() {
     // When a second instance detects the lock, it sends SIGUSR1 to the running instance
     // which triggers window show+focus (handles clicking the app icon while already running).
     #[cfg(target_os = "linux")]
-    let _lock_file = {
+    let _lock_file = if automation { None } else {
         use std::io::{Read as _, Write as _};
         use std::os::unix::io::AsRawFd;
 
@@ -4328,8 +4334,13 @@ fn main() {
         }
     };
 
-    let builder = tauri::Builder::default()
-        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+    let builder = tauri::Builder::default();
+    // Same automation carve-out as the flock above: the D-Bus single-instance plugin
+    // would make a second test-launched instance forward-and-exit instead of starting.
+    let builder = if automation {
+        builder
+    } else {
+        builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
             // When a second instance is launched, focus the main window
             if let Some(window) = app.get_webview_window("main") {
                 let _ = window.set_focus();
@@ -4337,6 +4348,8 @@ fn main() {
                 let _ = window.show();
             }
         }))
+    };
+    let builder = builder
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_shell::init())

--- a/src/utils/dateFormat.js
+++ b/src/utils/dateFormat.js
@@ -16,7 +16,18 @@ const DATE_PRESETS = {
  * it directly passed on a new local Node and threw `navigator is not defined`
  * on CI's Node 20.
  */
-const _locale = () => (typeof navigator !== 'undefined' ? navigator.language : undefined);
+const _locale = () => {
+  const lang = typeof navigator !== 'undefined' ? navigator.language : undefined;
+  if (!lang) return undefined;
+  // WebKitGTK reports the raw POSIX locale — "C" on systems without LANG set —
+  // which is not a BCP 47 tag and makes every Intl constructor throw RangeError,
+  // crashing the app into the error boundary. Fall back to the runtime default.
+  try {
+    return Intl.DateTimeFormat.supportedLocalesOf([lang]).length ? lang : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 /**
  * Build Intl.DateTimeFormat options for time based on the timeFormat setting.

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -22,20 +22,45 @@
  */
 export async function waitForApp(timeout = 30_000) {
   // First, wait for *any* content to render (onboarding, welcome, or sidebar)
-  await browser.waitUntil(
-    async () => {
-      return browser.execute(() => {
-        return document.querySelector('[data-testid="sidebar"]') !== null ||
-          (document.body?.textContent || '').includes('Get Started') ||
-          (document.body?.textContent || '').includes('Add Your First Account');
-      });
-    },
-    {
-      timeout,
-      timeoutMsg: `App did not render any content within ${timeout}ms`,
-      interval: 500,
-    },
-  );
+  try {
+    await browser.waitUntil(
+      async () => {
+        return browser.execute(() => {
+          return document.querySelector('[data-testid="sidebar"]') !== null ||
+            (document.body?.textContent || '').includes('Get Started') ||
+            (document.body?.textContent || '').includes('Add Your First Account');
+        });
+      },
+      {
+        timeout,
+        timeoutMsg: `App did not render any content within ${timeout}ms`,
+        interval: 500,
+      },
+    );
+  } catch (err) {
+    // Diagnostics for headless CI: what is the webview actually showing?
+    try {
+      const dom = await browser.execute(() => ({
+        readyState: document.readyState,
+        href: location.href,
+        title: document.title,
+        rootPresent: document.querySelector('#root') !== null,
+        bodyLength: document.body?.innerHTML?.length ?? -1,
+        bodyHead: (document.body?.innerHTML || '').slice(0, 1500),
+      }));
+      console.log('[waitForApp] DOM at timeout:', JSON.stringify(dom));
+    } catch (e) {
+      console.log('[waitForApp] DOM dump failed:', e.message);
+    }
+    try {
+      if (browser.testDataDir) {
+        await browser.saveScreenshot(`${browser.testDataDir}/waitforapp-${Date.now()}.png`);
+      }
+    } catch (e) {
+      console.log('[waitForApp] screenshot failed:', e.message);
+    }
+    throw err;
+  }
 
   // Auto-dismiss onboarding if present
   const dismissedOnboarding = await browser.execute(() => {

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -20,6 +20,35 @@
  *
  * @returns {'ready' | 'welcome'}
  */
+// Diagnostics for headless CI: what is the webview actually showing?
+async function dumpAppState(label) {
+  try {
+    const dom = await browser.execute(() => ({
+      readyState: document.readyState,
+      href: location.href,
+      title: document.title,
+      rootPresent: document.querySelector('#root') !== null,
+      sidebar: (() => {
+        const s = document.querySelector('[data-testid="sidebar"]');
+        return s ? { offsetHeight: s.offsetHeight, rect: s.getBoundingClientRect() } : null;
+      })(),
+      bodyText: (document.body?.textContent || '').slice(0, 500),
+      bodyLength: document.body?.innerHTML?.length ?? -1,
+      bodyHead: (document.body?.innerHTML || '').slice(0, 1500),
+    }));
+    console.log(`[waitForApp] DOM at ${label}:`, JSON.stringify(dom));
+  } catch (e) {
+    console.log(`[waitForApp] DOM dump failed (${label}):`, e.message);
+  }
+  try {
+    if (browser.testDataDir) {
+      await browser.saveScreenshot(`${browser.testDataDir}/waitforapp-${label}-${Date.now()}.png`);
+    }
+  } catch (e) {
+    console.log(`[waitForApp] screenshot failed (${label}):`, e.message);
+  }
+}
+
 export async function waitForApp(timeout = 30_000) {
   // First, wait for *any* content to render (onboarding, welcome, or sidebar)
   try {
@@ -38,27 +67,7 @@ export async function waitForApp(timeout = 30_000) {
       },
     );
   } catch (err) {
-    // Diagnostics for headless CI: what is the webview actually showing?
-    try {
-      const dom = await browser.execute(() => ({
-        readyState: document.readyState,
-        href: location.href,
-        title: document.title,
-        rootPresent: document.querySelector('#root') !== null,
-        bodyLength: document.body?.innerHTML?.length ?? -1,
-        bodyHead: (document.body?.innerHTML || '').slice(0, 1500),
-      }));
-      console.log('[waitForApp] DOM at timeout:', JSON.stringify(dom));
-    } catch (e) {
-      console.log('[waitForApp] DOM dump failed:', e.message);
-    }
-    try {
-      if (browser.testDataDir) {
-        await browser.saveScreenshot(`${browser.testDataDir}/waitforapp-${Date.now()}.png`);
-      }
-    } catch (e) {
-      console.log('[waitForApp] screenshot failed:', e.message);
-    }
+    await dumpAppState('no-content');
     throw err;
   }
 
@@ -80,22 +89,28 @@ export async function waitForApp(timeout = 30_000) {
   }
 
   // Now check if we land on sidebar (has accounts) or welcome screen (no accounts)
-  const state = await browser.waitUntil(
-    async () => {
-      return browser.execute(() => {
-        const sidebar = document.querySelector('[data-testid="sidebar"]');
-        if (sidebar && sidebar.offsetHeight > 0) return 'ready';
-        if (document.body.textContent.includes('Add Your First Account')) return 'welcome';
-        // Still loading (keychain prompt, etc.)
-        return null;
-      });
-    },
-    {
-      timeout: timeout - 5000,
-      timeoutMsg: `App stuck after onboarding — neither sidebar nor welcome screen appeared`,
-      interval: 500,
-    },
-  );
+  let state;
+  try {
+    state = await browser.waitUntil(
+      async () => {
+        return browser.execute(() => {
+          const sidebar = document.querySelector('[data-testid="sidebar"]');
+          if (sidebar && sidebar.offsetHeight > 0) return 'ready';
+          if (document.body.textContent.includes('Add Your First Account')) return 'welcome';
+          // Still loading (keychain prompt, etc.)
+          return null;
+        });
+      },
+      {
+        timeout: timeout - 5000,
+        timeoutMsg: `App stuck after onboarding — neither sidebar nor welcome screen appeared`,
+        interval: 500,
+      },
+    );
+  } catch (err) {
+    await dumpAppState('stuck-after-onboarding');
+    throw err;
+  }
 
   return state;
 }

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -207,6 +207,27 @@ export async function pressSequence(key1, key2) {
  * match hits ordinary sidebar chrome, so it reports "open" over the mail view and
  * every later click lands on the wrong element.
  */
+/**
+ * Click a settings navigation button by its exact visible label. Works for
+ * top-level tabs ('Templates', 'Storage', 'Accounts', 'General') and the
+ * General tab's sub-tabs ('Appearance', 'Behavior', 'Notifications',
+ * 'Keyboard Shortcuts') — the settings restructure moved sections off the
+ * old flat General page onto these.
+ */
+export async function clickSettingsNav(label) {
+  const clicked = await browser.execute((wanted) => {
+    for (const btn of document.querySelectorAll('button')) {
+      if (btn.offsetHeight > 0 && btn.textContent.trim() === wanted) {
+        btn.click();
+        return true;
+      }
+    }
+    return false;
+  }, label);
+  await browser.pause(400);
+  return clicked;
+}
+
 export async function openSettings() {
   const isOpen = () => browser.execute(() => {
     const el = document.querySelector('[data-testid="settings-page"]');

--- a/tests/e2e/ui-compose-templates.test.js
+++ b/tests/e2e/ui-compose-templates.test.js
@@ -10,7 +10,7 @@
  * 6. Clean up by deleting the template
  */
 
-import { waitForApp, openSettings, closeSettings, pressKey } from './helpers.js';
+import { waitForApp, openSettings, closeSettings, clickSettingsNav, pressKey } from './helpers.js';
 
 const TEST_TEMPLATE_NAME = 'E2E Compose Template';
 const TEST_TEMPLATE_BODY = 'Hello, this is a test template inserted by E2E automation.';
@@ -31,6 +31,8 @@ describe('Compose Modal & Templates', function () {
     it('should create a test template', async function () {
       await openSettings();
       await browser.pause(400);
+      // Templates moved to their own top-level tab
+      await clickSettingsNav('Templates');
 
       // Click "Add Template"
       const clickedAdd = await browser.execute(() => {
@@ -225,6 +227,8 @@ describe('Compose Modal & Templates', function () {
     it('should remove the test template from settings', async function () {
       await openSettings();
       await browser.pause(400);
+      // Templates moved to their own top-level tab
+      await clickSettingsNav('Templates');
 
       // Find and delete the template
       const deleted = await browser.execute((name) => {

--- a/tests/e2e/ui-compose-templates.test.js
+++ b/tests/e2e/ui-compose-templates.test.js
@@ -176,9 +176,12 @@ describe('Compose Modal & Templates', function () {
       }, TEST_TEMPLATE_NAME);
       await browser.pause(500);
 
-      // Verify the compose body textarea contains the template text
+      // Verify the compose body contains the template text. The body is a
+      // rich-text (contentEditable) editor now, so check innerText first;
+      // keep the textarea paths for older layouts.
       const bodyContainsTemplate = await browser.execute((expectedText) => {
         const body = document.querySelector('[data-testid="compose-body"]');
+        if (body && (body.innerText || '').includes(expectedText)) return true;
         if (body && body.value && body.value.includes(expectedText)) return true;
         const textareas = document.querySelectorAll('textarea');
         for (const ta of textareas) {

--- a/tests/e2e/ui-settings-extended.test.js
+++ b/tests/e2e/ui-settings-extended.test.js
@@ -9,7 +9,7 @@
  * - Accounts Tab (display name, signature, avatar color picker)
  */
 
-import { waitForApp, openSettings, closeSettings, pressKey } from './helpers.js';
+import { waitForApp, openSettings, closeSettings, clickSettingsNav, pressKey } from './helpers.js';
 
 describe('Settings Page — Extended', function () {
   this.timeout(30000);
@@ -156,11 +156,13 @@ describe('Settings Page — Extended', function () {
   // -----------------------------------------------------------------------
   // General Tab — Search & History
   // -----------------------------------------------------------------------
-  describe('General Tab — Search & History', function () {
+  describe('Behavior — Search & History', function () {
     before(async function () {
       if (appState !== 'ready') this.skip();
       await openSettings();
       await browser.pause(300);
+      // Search/filter history moved to the General tab's Behavior sub-tab
+      await clickSettingsNav('Behavior');
       // Scroll down to find Search & History section
       await browser.execute(() => {
         const allText = document.querySelectorAll('h4, h3, div');
@@ -228,20 +230,10 @@ describe('Settings Page — Extended', function () {
   // -----------------------------------------------------------------------
   // General Tab — Notifications Details
   // -----------------------------------------------------------------------
-  describe('General Tab — Notifications Details', function () {
+  describe('Notifications & Behavior — details', function () {
     before(async function () {
       if (appState !== 'ready') this.skip();
       await openSettings();
-      await browser.pause(300);
-      // Scroll to notifications section
-      await browser.execute(() => {
-        const section = document.querySelector('[data-testid="settings-notifications"]');
-        if (section) {
-          section.scrollIntoView({ behavior: 'instant' });
-          return true;
-        }
-        return false;
-      });
       await browser.pause(300);
     });
 
@@ -250,6 +242,8 @@ describe('Settings Page — Extended', function () {
     });
 
     it('should have badge count toggle', async function () {
+      // Badge settings live on the Notifications sub-tab
+      await clickSettingsNav('Notifications');
       const found = await browser.execute(() => {
         const text = document.body.innerText.toLowerCase();
         return text.includes('badge');
@@ -258,11 +252,12 @@ describe('Settings Page — Extended', function () {
     });
 
     it('should have mark as read mode dropdown', async function () {
+      // Mark as Read moved to the Behavior sub-tab
+      await clickSettingsNav('Behavior');
       const options = await browser.execute(() => {
-        // Scope to the notifications section to avoid matching the date-format dropdown
-        const section = document.querySelector('[data-testid="settings-notifications"]');
-        const container = section || document;
-        const selects = container.querySelectorAll('select');
+        // The date-format dropdown lives on the Appearance sub-tab, so it is
+        // not mounted here — document scope is unambiguous.
+        const selects = document.querySelectorAll('select');
         for (const select of selects) {
           const opts = Array.from(select.options).map(o => o.value);
           if (opts.includes('auto') && opts.includes('manual')) {

--- a/tests/e2e/ui-settings.test.js
+++ b/tests/e2e/ui-settings.test.js
@@ -49,60 +49,46 @@ describe('Settings Page', function () {
       const found = await browser.execute(() => {
         const section = document.querySelector('[data-testid="settings-undo-send"]');
         if (section && section.offsetHeight > 0) return true;
-        return document.body.innerText.includes('Enable Undo Send');
+        return document.body.innerText.includes('Send Delay');
       });
       expect(found).toBe(true);
     });
 
-    it('should show delay dropdown when undo send is toggled on', async function () {
-      // First, check if undo send is already on (state persists between sessions)
-      const alreadyOn = await browser.execute(() => {
-        return document.body.innerText.includes('Undo send delay');
-      });
+    it('should offer send delay options and warn when a delay is set', async function () {
+      // Undo Send is a single "Send Delay" select now (0 = off) in the Sending
+      // section — the old Enable toggle + delay dropdown pair is gone.
+      const setDelay = (value) => browser.execute((v) => {
+        const select = document.querySelector('[data-testid="settings-undo-send"] select');
+        if (!select) return false;
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLSelectElement.prototype, 'value'
+        ).set;
+        setter.call(select, v);
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+        return true;
+      }, value);
 
-      if (!alreadyOn) {
-        // Toggle it ON
-        await browser.execute(() => {
-          const labels = document.querySelectorAll('div');
-          for (const label of labels) {
-            if (label.textContent.trim() === 'Enable Undo Send') {
-              const container = label.closest('.flex') || label.parentElement?.parentElement;
-              if (!container) continue;
-              const toggle = container.querySelector('.toggle-switch');
-              if (toggle) {
-                toggle.click();
-                return true;
-              }
-            }
-          }
-          return false;
-        });
-        await browser.pause(400);
-      }
-
-      // Check if delay dropdown is visible
-      const hasDropdown = await browser.execute(() => {
-        return document.body.innerText.includes('Undo send delay');
+      const options = await browser.execute(() => {
+        const section = document.querySelector('[data-testid="settings-undo-send"]');
+        const select = section && section.querySelector('select');
+        return select ? Array.from(select.options).map(o => o.value) : null;
       });
-      expect(hasDropdown).toBe(true);
+      expect(options).not.toBe(null);
+      expect(options).toContain('0');
+      expect(options).toContain('30');
 
-      // Toggle back off to restore state
-      await browser.execute(() => {
-        const labels = document.querySelectorAll('div');
-        for (const label of labels) {
-          if (label.textContent.trim() === 'Enable Undo Send') {
-            const container = label.closest('.flex') || label.parentElement?.parentElement;
-            if (!container) continue;
-            const toggle = container.querySelector('.toggle-switch');
-            if (toggle) {
-              toggle.click();
-              return true;
-            }
-          }
-        }
-        return false;
-      });
+      // Selecting a delay surfaces the stay-awake warning
+      expect(await setDelay('30')).toBe(true);
       await browser.pause(300);
+      const hasWarning = await browser.execute(() => {
+        const section = document.querySelector('[data-testid="settings-undo-send"]');
+        return (section?.innerText || '').includes('stay awake');
+      });
+      expect(hasWarning).toBe(true);
+
+      // Restore Off
+      await setDelay('0');
+      await browser.pause(200);
     });
   });
 

--- a/tests/e2e/ui-settings.test.js
+++ b/tests/e2e/ui-settings.test.js
@@ -9,7 +9,7 @@
  * - Storage tab with Auto-Cleanup and Pro badge
  */
 
-import { waitForApp, openSettings, closeSettings, pressKey } from './helpers.js';
+import { waitForApp, openSettings, closeSettings, clickSettingsNav, pressKey } from './helpers.js';
 
 describe('Settings Page', function () {
   this.timeout(30000);
@@ -32,11 +32,13 @@ describe('Settings Page', function () {
     await closeSettings();
   });
 
-  describe('General Tab — Undo Send', function () {
+  describe('Behavior — Undo Send', function () {
     before(async function () {
       if (!settingsAccessible) this.skip();
       await openSettings();
       await browser.pause(300);
+      // Undo Send lives on the General tab's Behavior sub-tab now
+      await clickSettingsNav('Behavior');
     });
 
     after(async function () {
@@ -104,11 +106,13 @@ describe('Settings Page', function () {
     });
   });
 
-  describe('General Tab — Email Templates', function () {
+  describe('Templates Tab — Email Templates', function () {
     before(async function () {
       if (!settingsAccessible) this.skip();
       await openSettings();
       await browser.pause(300);
+      // Templates moved to their own top-level tab
+      await clickSettingsNav('Templates');
     });
 
     after(async function () {
@@ -230,11 +234,13 @@ describe('Settings Page', function () {
     });
   });
 
-  describe('General Tab — Notifications', function () {
+  describe('Notifications — master toggle and preview', function () {
     before(async function () {
       if (!settingsAccessible) this.skip();
       await openSettings();
       await browser.pause(300);
+      await clickSettingsNav('General');
+      await clickSettingsNav('Notifications');
     });
 
     after(async function () {
@@ -262,11 +268,13 @@ describe('Settings Page', function () {
     });
   });
 
-  describe('General Tab — Keyboard Shortcuts', function () {
+  describe('Keyboard Shortcuts', function () {
     before(async function () {
       if (!settingsAccessible) this.skip();
       await openSettings();
       await browser.pause(300);
+      await clickSettingsNav('General');
+      await clickSettingsNav('Keyboard Shortcuts');
     });
 
     after(async function () {
@@ -342,16 +350,16 @@ describe('Settings Page', function () {
       expect(found).toBe(true);
     });
 
-    it('should show Pro badge on Auto-Cleanup for non-paid users', async function () {
+    it('should show Premium badge on Auto-Cleanup for non-paid users', async function () {
       const hasBadge = await browser.execute(() => {
         const section = document.querySelector('[data-testid="settings-auto-cleanup"]');
         if (section) {
-          return section.innerText.includes('Pro');
+          return section.innerText.includes('Premium');
         }
         const headings = document.querySelectorAll('h4');
         for (const h of headings) {
           if (h.textContent.includes('Auto-Cleanup')) {
-            return h.textContent.includes('Pro');
+            return h.textContent.includes('Premium');
           }
         }
         return false;

--- a/tests/unit/dateFormat.test.js
+++ b/tests/unit/dateFormat.test.js
@@ -46,4 +46,17 @@ describe('dateFormat without a navigator global', () => {
     // en-GB is 24-hour, so 15:09 UTC must not come back with an am/pm marker.
     expect(formatTime(DATE)).not.toMatch(/[ap]m/i);
   });
+
+  // WebKitGTK reports the raw POSIX locale: navigator.language === "C" on any
+  // Linux without LANG set (headless CI, minimal desktops). "C" is not a BCP 47
+  // tag — passing it to Intl throws RangeError and crashed the whole app into
+  // its error boundary. The formatters must fall back to the runtime default.
+  for (const [name, call] of cases) {
+    it(`${name} survives a POSIX "C" locale`, () => {
+      vi.stubGlobal('navigator', { language: 'C' });
+      const out = call();
+      expect(out).toBeTruthy();
+      expect(out).toEqual(expect.any(String));
+    });
+  }
 });

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -130,7 +130,10 @@ export const config = {
     mockServers.forEach((s, i) => console.log(`[wdio] Mock IMAP for ${MOCK_ACCOUNTS[i].email}: ${s.host}:${s.port}`));
 
     return new Promise((resolve) => {
-      tauriWd = spawn('tauri-wd', ['--port', '4444'], {
+      // Trace level in CI: tauri-wd relays the app's stdout lines at
+      // debug/trace, which is the only place frontend/daemon boot output
+      // is visible on a headless runner.
+      tauriWd = spawn('tauri-wd', ['--port', '4444', ...(process.env.CI ? ['--log-level', 'trace'] : [])], {
         stdio: ['ignore', 'pipe', 'pipe'],
         // Own process group: killing it takes the app (and its daemon) with it.
         detached: true,

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -89,6 +89,11 @@ export const config = {
     ui: 'bdd',
     timeout: 120000,
   },
+  // Session init issues getWindowHandle immediately after tauri-wd reports the
+  // plugin port, but the app (debug build, cold CI runner) can need tens of
+  // seconds more before the main window exists. The default 3 retries give up
+  // after ~1.5s; 15 retries back off to ~50s total, which covers the boot gap.
+  connectionRetryCount: process.env.CI ? 15 : 3,
   specFileRetries: process.env.CI ? 1 : 0,
   specFileRetriesDelay: 5,
   specFileRetriesDeferred: true,


### PR DESCRIPTION
Investigation branch for the perma-red e2e job (runs 30804550669, 30264448742, 30245295393).

Root cause chain:
1. wdio's session init calls getWindowHandle ~40ms after tauri-wd reports the plugin port; on a cold CI runner the debug app needs tens of seconds more before its window exists. Default 3 retries give up after ~1.5s → `no window`.
2. That failed worker never deletes its session, so the first app keeps running. The Linux flock single-instance guard then makes every subsequent launch exit(0) instantly → `App did not report plugin port in time` for the rest of the suite.

Fixes: CI-only connectionRetryCount bump, single-instance carve-out under TAURI_WEBVIEW_AUTOMATION, WebKit DMABUF/AT-SPI/dbus env hardening. Includes a temporary probe step that logs when the app window maps under xvfb — to be removed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)